### PR TITLE
fix: Add outbound webhook notifications so release pipeline failures surface outside the UI

### DIFF
--- a/__tests__/api/settings.test.ts
+++ b/__tests__/api/settings.test.ts
@@ -186,6 +186,13 @@ describe('settings API', () => {
         'fix_ci_retry_window_seconds',
         'fix_ci_fast_crash_ms',
         'agent_templates',
+        'notification_webhook_url',
+        'notification_webhook_secret',
+        'notification_on_release_success',
+        'notification_on_release_fail',
+        'notification_on_fix_loop_exhausted',
+        'notification_on_review_do_not_ship',
+        'notification_on_agent_run_fail',
       ];
 
       const body = Object.fromEntries(validKeys.map((k) => [k, 'test-value']));

--- a/__tests__/api/settings/test-notification.test.ts
+++ b/__tests__/api/settings/test-notification.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { NextRequest } from 'next/server';
+
+describe('POST /api/settings/test-notification', () => {
+  let POST: (req: NextRequest) => Promise<Response>;
+  let mockSendTestNotification: ReturnType<typeof vi.fn>;
+
+  beforeEach(async () => {
+    vi.resetModules();
+    mockSendTestNotification = vi.fn().mockResolvedValue({ ok: true });
+    vi.doMock('@/lib/notifications', () => ({
+      sendTestNotification: mockSendTestNotification,
+    }));
+
+    const mod = await import('@/app/api/settings/test-notification/route');
+    POST = mod.POST;
+  });
+
+  afterEach(() => {
+    vi.resetModules();
+  });
+
+  it('returns 400 when webhook_url is missing', async () => {
+    const req = new NextRequest('http://localhost/api/settings/test-notification', {
+      method: 'POST',
+      body: JSON.stringify({ webhook_secret: 'secret' }),
+    });
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+    const data = await res.json();
+    expect(data.ok).toBe(false);
+    expect(data.error).toMatch(/required/i);
+    expect(mockSendTestNotification).not.toHaveBeenCalled();
+  });
+
+  it('calls sendTestNotification with url and secret', async () => {
+    const req = new NextRequest('http://localhost/api/settings/test-notification', {
+      method: 'POST',
+      body: JSON.stringify({ webhook_url: 'https://hooks.slack.com/x', webhook_secret: 'secret123' }),
+    });
+    await POST(req);
+    expect(mockSendTestNotification).toHaveBeenCalledWith('https://hooks.slack.com/x', 'secret123');
+  });
+
+  it('calls sendTestNotification with empty string when secret is omitted', async () => {
+    const req = new NextRequest('http://localhost/api/settings/test-notification', {
+      method: 'POST',
+      body: JSON.stringify({ webhook_url: 'https://ntfy.sh/topic' }),
+    });
+    await POST(req);
+    expect(mockSendTestNotification).toHaveBeenCalledWith('https://ntfy.sh/topic', '');
+  });
+
+  it('returns { ok: true } on success', async () => {
+    mockSendTestNotification.mockResolvedValue({ ok: true });
+    const req = new NextRequest('http://localhost/api/settings/test-notification', {
+      method: 'POST',
+      body: JSON.stringify({ webhook_url: 'https://example.com/hook' }),
+    });
+    const res = await POST(req);
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.ok).toBe(true);
+  });
+
+  it('forwards { ok: false, error } on delivery failure', async () => {
+    mockSendTestNotification.mockResolvedValue({ ok: false, error: 'Webhook request failed' });
+    const req = new NextRequest('http://localhost/api/settings/test-notification', {
+      method: 'POST',
+      body: JSON.stringify({ webhook_url: 'https://example.com/hook' }),
+    });
+    const res = await POST(req);
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.ok).toBe(false);
+    expect(data.error).toBe('Webhook request failed');
+  });
+
+  it('returns 500 when sendTestNotification throws', async () => {
+    mockSendTestNotification.mockRejectedValue(new Error('unexpected crash'));
+    const req = new NextRequest('http://localhost/api/settings/test-notification', {
+      method: 'POST',
+      body: JSON.stringify({ webhook_url: 'https://example.com/hook' }),
+    });
+    const res = await POST(req);
+    expect(res.status).toBe(500);
+    const data = await res.json();
+    expect(data.ok).toBe(false);
+  });
+});

--- a/__tests__/lib/config.test.ts
+++ b/__tests__/lib/config.test.ts
@@ -70,6 +70,13 @@ describe('config', () => {
         log_retention_count: 200,
         log_retention_days: 30,
         job_row_retention_days: 180,
+        notification_webhook_url: '',
+        notification_webhook_secret: '',
+        notification_on_release_success: false,
+        notification_on_release_fail: false,
+        notification_on_fix_loop_exhausted: false,
+        notification_on_review_do_not_ship: false,
+        notification_on_agent_run_fail: false,
       });
     });
 

--- a/__tests__/lib/notifications.test.ts
+++ b/__tests__/lib/notifications.test.ts
@@ -1,0 +1,354 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+type Settings = {
+  notification_webhook_url: string;
+  notification_webhook_secret: string;
+  notification_on_release_success: boolean;
+  notification_on_release_fail: boolean;
+  notification_on_fix_loop_exhausted: boolean;
+  notification_on_review_do_not_ship: boolean;
+  notification_on_agent_run_fail: boolean;
+};
+
+function defaultSettings(overrides: Partial<Settings> = {}): Settings {
+  return {
+    notification_webhook_url: '',
+    notification_webhook_secret: '',
+    notification_on_release_success: false,
+    notification_on_release_fail: false,
+    notification_on_fix_loop_exhausted: false,
+    notification_on_review_do_not_ship: false,
+    notification_on_agent_run_fail: false,
+    ...overrides,
+  };
+}
+
+const SLACK_URL = 'https://hooks.slack.com/services/T000/B000/xxx';
+const DISCORD_URL = 'https://discord.com/api/webhooks/123/abc';
+const GENERIC_URL = 'https://ntfy.sh/my-topic';
+
+describe('lib/notifications', () => {
+  let mockGetSettings: ReturnType<typeof vi.fn>;
+  let mockFetch: ReturnType<typeof vi.fn>;
+
+  beforeEach(async () => {
+    vi.resetModules();
+    mockGetSettings = vi.fn().mockReturnValue(defaultSettings());
+    vi.doMock('@/lib/config', () => ({ getSettings: mockGetSettings }));
+    mockFetch = vi.fn().mockResolvedValue({ ok: true });
+    vi.stubGlobal('fetch', mockFetch);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.resetModules();
+  });
+
+  // Helper to flush the microtask / promise queue so fire-and-forget calls land
+  async function flush() {
+    await new Promise<void>((r) => setTimeout(r, 10));
+  }
+
+  describe('notify()', () => {
+    it('is a no-op when event is disabled', async () => {
+      mockGetSettings.mockReturnValue(
+        defaultSettings({ notification_webhook_url: GENERIC_URL, notification_on_release_success: false }),
+      );
+      const { notify } = await import('@/lib/notifications');
+      await notify({ event: 'release_success', project: 'p', job_id: 'j', status: 'success', timestamp: Date.now() });
+      await flush();
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+
+    it('is a no-op when webhook URL is blank even if event enabled', async () => {
+      mockGetSettings.mockReturnValue(
+        defaultSettings({ notification_webhook_url: '', notification_on_release_success: true }),
+      );
+      const { notify } = await import('@/lib/notifications');
+      await notify({ event: 'release_success', project: 'p', job_id: 'j', status: 'success', timestamp: Date.now() });
+      await flush();
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+
+    it('calls fetch when event is enabled and URL is set', async () => {
+      mockGetSettings.mockReturnValue(
+        defaultSettings({ notification_webhook_url: GENERIC_URL, notification_on_release_success: true }),
+      );
+      const { notify } = await import('@/lib/notifications');
+      await notify({ event: 'release_success', project: 'myapp', job_id: 'job-1', status: 'success', timestamp: Date.now() });
+      await flush();
+      expect(mockFetch).toHaveBeenCalledOnce();
+      const [url] = mockFetch.mock.calls[0];
+      expect(url).toBe(GENERIC_URL);
+    });
+
+    it('posts raw JSON payload to generic webhooks', async () => {
+      mockGetSettings.mockReturnValue(
+        defaultSettings({ notification_webhook_url: GENERIC_URL, notification_on_release_fail: true }),
+      );
+      const { notify } = await import('@/lib/notifications');
+      await notify({ event: 'release_fail', project: 'p', job_id: 'j', status: 'failed', timestamp: 1000 });
+      await flush();
+
+      const [, opts] = mockFetch.mock.calls[0];
+      const body = JSON.parse(opts.body);
+      expect(body.event).toBe('release_fail');
+      expect(body.project).toBe('p');
+      expect(body.status).toBe('failed');
+    });
+
+    it('posts Slack block-kit format for hooks.slack.com URLs', async () => {
+      mockGetSettings.mockReturnValue(
+        defaultSettings({ notification_webhook_url: SLACK_URL, notification_on_release_success: true }),
+      );
+      const { notify } = await import('@/lib/notifications');
+      await notify({ event: 'release_success', project: 'p', job_id: 'j', status: 'success', timestamp: Date.now() });
+      await flush();
+
+      const [, opts] = mockFetch.mock.calls[0];
+      const body = JSON.parse(opts.body);
+      expect(body).toHaveProperty('blocks');
+      expect(Array.isArray(body.blocks)).toBe(true);
+    });
+
+    it('posts Discord embed format for discord.com webhook URLs', async () => {
+      mockGetSettings.mockReturnValue(
+        defaultSettings({ notification_webhook_url: DISCORD_URL, notification_on_release_fail: true }),
+      );
+      const { notify } = await import('@/lib/notifications');
+      await notify({ event: 'release_fail', project: 'p', job_id: 'j', status: 'failed', timestamp: Date.now() });
+      await flush();
+
+      const [, opts] = mockFetch.mock.calls[0];
+      const body = JSON.parse(opts.body);
+      expect(body).toHaveProperty('embeds');
+      expect(Array.isArray(body.embeds)).toBe(true);
+    });
+
+    it('adds X-TamTam-Signature header when secret is configured', async () => {
+      mockGetSettings.mockReturnValue(
+        defaultSettings({
+          notification_webhook_url: GENERIC_URL,
+          notification_webhook_secret: 'mysecret',
+          notification_on_agent_run_fail: true,
+        }),
+      );
+      const { notify } = await import('@/lib/notifications');
+      await notify({ event: 'agent_run_fail', project: 'p', job_id: 'j', status: 'failed', timestamp: Date.now() });
+      await flush();
+
+      const [, opts] = mockFetch.mock.calls[0];
+      expect(opts.headers['X-TamTam-Signature']).toBeDefined();
+      expect(typeof opts.headers['X-TamTam-Signature']).toBe('string');
+      expect(opts.headers['X-TamTam-Signature']).toMatch(/^[0-9a-f]{64}$/);
+    });
+
+    it('omits X-TamTam-Signature header when no secret configured', async () => {
+      mockGetSettings.mockReturnValue(
+        defaultSettings({ notification_webhook_url: GENERIC_URL, notification_on_review_do_not_ship: true }),
+      );
+      const { notify } = await import('@/lib/notifications');
+      await notify({ event: 'review_do_not_ship', project: 'p', job_id: 'j', status: 'failed', timestamp: Date.now() });
+      await flush();
+
+      const [, opts] = mockFetch.mock.calls[0];
+      expect(opts.headers['X-TamTam-Signature']).toBeUndefined();
+    });
+
+    it('fills in timestamp automatically if not provided', async () => {
+      mockGetSettings.mockReturnValue(
+        defaultSettings({ notification_webhook_url: GENERIC_URL, notification_on_release_success: true }),
+      );
+      const { notify } = await import('@/lib/notifications');
+      const before = Date.now();
+      await notify({ event: 'release_success', project: 'p', job_id: 'j', status: 'success', timestamp: 0 });
+      await flush();
+
+      const [, opts] = mockFetch.mock.calls[0];
+      const body = JSON.parse(opts.body);
+      expect(body.timestamp).toBeGreaterThanOrEqual(before);
+    });
+  });
+
+  describe('adapter selection (detectWebhookType)', () => {
+    it('uses slack format for hooks.slack.com', async () => {
+      mockGetSettings.mockReturnValue(
+        defaultSettings({ notification_webhook_url: SLACK_URL, notification_on_release_success: true }),
+      );
+      const { notify } = await import('@/lib/notifications');
+      await notify({ event: 'release_success', project: 'p', job_id: 'j', status: 'success', timestamp: Date.now() });
+      await flush();
+
+      const body = JSON.parse(mockFetch.mock.calls[0][1].body);
+      expect(body).toHaveProperty('blocks');
+      expect(body).not.toHaveProperty('embeds');
+      expect(body).not.toHaveProperty('event');
+    });
+
+    it('uses discord format for discord.com/api/webhooks', async () => {
+      mockGetSettings.mockReturnValue(
+        defaultSettings({ notification_webhook_url: DISCORD_URL, notification_on_release_success: true }),
+      );
+      const { notify } = await import('@/lib/notifications');
+      await notify({ event: 'release_success', project: 'p', job_id: 'j', status: 'success', timestamp: Date.now() });
+      await flush();
+
+      const body = JSON.parse(mockFetch.mock.calls[0][1].body);
+      expect(body).toHaveProperty('embeds');
+      expect(body).not.toHaveProperty('blocks');
+    });
+
+    it('uses raw JSON for generic URLs', async () => {
+      mockGetSettings.mockReturnValue(
+        defaultSettings({ notification_webhook_url: 'https://ntfy.sh/topic', notification_on_release_success: true }),
+      );
+      const { notify } = await import('@/lib/notifications');
+      await notify({ event: 'release_success', project: 'p', job_id: 'j', status: 'success', timestamp: Date.now() });
+      await flush();
+
+      const body = JSON.parse(mockFetch.mock.calls[0][1].body);
+      expect(body).toHaveProperty('event', 'release_success');
+    });
+  });
+
+  describe('HMAC signing', () => {
+    it('produces consistent signatures for same payload + secret', async () => {
+      mockGetSettings.mockReturnValue(
+        defaultSettings({
+          notification_webhook_url: GENERIC_URL,
+          notification_webhook_secret: 'testsecret',
+          notification_on_release_success: true,
+        }),
+      );
+      const { notify } = await import('@/lib/notifications');
+      const payload = { event: 'release_success' as const, project: 'p', job_id: 'j', status: 'success' as const, timestamp: 42 };
+
+      await notify({ ...payload });
+      await flush();
+      const sig1 = mockFetch.mock.calls[0][1].headers['X-TamTam-Signature'];
+
+      mockFetch.mockClear();
+      await notify({ ...payload });
+      await flush();
+      const sig2 = mockFetch.mock.calls[0][1].headers['X-TamTam-Signature'];
+
+      expect(sig1).toBe(sig2);
+    });
+
+    it('produces different signatures for different secrets', async () => {
+      const { notify } = await import('@/lib/notifications');
+      const payload = { event: 'release_success' as const, project: 'p', job_id: 'j', status: 'success' as const, timestamp: 42 };
+
+      mockGetSettings.mockReturnValue(
+        defaultSettings({ notification_webhook_url: GENERIC_URL, notification_webhook_secret: 'secret1', notification_on_release_success: true }),
+      );
+      await notify({ ...payload });
+      await flush();
+      const sig1 = mockFetch.mock.calls[0][1].headers['X-TamTam-Signature'];
+
+      mockFetch.mockClear();
+      mockGetSettings.mockReturnValue(
+        defaultSettings({ notification_webhook_url: GENERIC_URL, notification_webhook_secret: 'secret2', notification_on_release_success: true }),
+      );
+      await notify({ ...payload });
+      await flush();
+      const sig2 = mockFetch.mock.calls[0][1].headers['X-TamTam-Signature'];
+
+      expect(sig1).not.toBe(sig2);
+    });
+  });
+
+  describe('retry and backoff (via sendTestNotification)', () => {
+    it('returns { ok: true } on first successful fetch', async () => {
+      mockFetch.mockResolvedValue({ ok: true });
+      const { sendTestNotification } = await import('@/lib/notifications');
+      const result = await sendTestNotification(GENERIC_URL, '');
+      expect(result).toEqual({ ok: true });
+      expect(mockFetch).toHaveBeenCalledOnce();
+    });
+
+    it('returns { ok: false } when URL is blank', async () => {
+      const { sendTestNotification } = await import('@/lib/notifications');
+      const result = await sendTestNotification('', '');
+      expect(result.ok).toBe(false);
+      expect(result.error).toMatch(/required/i);
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+
+    it('retries up to maxRetries (3) times on fetch failure and returns { ok: false }', async () => {
+      vi.useFakeTimers();
+      mockFetch.mockRejectedValue(new Error('network error'));
+
+      const { sendTestNotification } = await import('@/lib/notifications');
+      const promise = sendTestNotification(GENERIC_URL, '');
+      await vi.runAllTimersAsync();
+      const result = await promise;
+
+      expect(result.ok).toBe(false);
+      expect(mockFetch).toHaveBeenCalledTimes(3);
+      vi.useRealTimers();
+    });
+
+    it('retries on HTTP error status and succeeds on retry', async () => {
+      vi.useFakeTimers();
+      mockFetch
+        .mockResolvedValueOnce({ ok: false, status: 503 })
+        .mockResolvedValueOnce({ ok: true });
+
+      const { sendTestNotification } = await import('@/lib/notifications');
+      const promise = sendTestNotification(GENERIC_URL, '');
+      await vi.runAllTimersAsync();
+      const result = await promise;
+
+      expect(result.ok).toBe(true);
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+      vi.useRealTimers();
+    });
+
+    it('succeeds immediately without retrying on 200', async () => {
+      mockFetch.mockResolvedValue({ ok: true });
+      const { sendTestNotification } = await import('@/lib/notifications');
+      const result = await sendTestNotification(GENERIC_URL, '');
+      expect(result.ok).toBe(true);
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('sendTestNotification()', () => {
+    it('sends a Slack-formatted body to Slack URLs', async () => {
+      mockFetch.mockResolvedValue({ ok: true });
+      const { sendTestNotification } = await import('@/lib/notifications');
+      await sendTestNotification(SLACK_URL, '');
+
+      const body = JSON.parse(mockFetch.mock.calls[0][1].body);
+      expect(body).toHaveProperty('blocks');
+    });
+
+    it('sends a Discord embed body to Discord URLs', async () => {
+      mockFetch.mockResolvedValue({ ok: true });
+      const { sendTestNotification } = await import('@/lib/notifications');
+      await sendTestNotification(DISCORD_URL, '');
+
+      const body = JSON.parse(mockFetch.mock.calls[0][1].body);
+      expect(body).toHaveProperty('embeds');
+    });
+
+    it('sends signature header when secret is provided', async () => {
+      mockFetch.mockResolvedValue({ ok: true });
+      const { sendTestNotification } = await import('@/lib/notifications');
+      await sendTestNotification(GENERIC_URL, 'myverysecretkey');
+
+      const headers = mockFetch.mock.calls[0][1].headers;
+      expect(headers['X-TamTam-Signature']).toMatch(/^[0-9a-f]{64}$/);
+    });
+
+    it('omits signature header when no secret provided', async () => {
+      mockFetch.mockResolvedValue({ ok: true });
+      const { sendTestNotification } = await import('@/lib/notifications');
+      await sendTestNotification(GENERIC_URL, '');
+
+      const headers = mockFetch.mock.calls[0][1].headers;
+      expect(headers['X-TamTam-Signature']).toBeUndefined();
+    });
+  });
+});

--- a/__tests__/lib/start-push.test.ts
+++ b/__tests__/lib/start-push.test.ts
@@ -581,7 +581,10 @@ describe('startProjectPush — push result tracking', () => {
       .mockImplementationOnce(() => resp(0, 'abc1234'))                   // git rev-parse
       .mockImplementationOnce(() => resp(0, 'fix/issue-42-fix-login-bug')) // git branch --show-current (in createIssuePR)
       .mockImplementationOnce(() => resp(0, 'refs/remotes/origin/main'))  // git symbolic-ref (in createIssuePR)
-      .mockImplementationOnce(() => resp(0, 'https://github.com/owner/repo/pull/99\n')); // gh pr create
+      .mockImplementationOnce(() => resp(0, 'https://github.com/owner/repo/pull/99\n')) // gh pr create
+      .mockImplementationOnce(() => resp(0, 'refs/remotes/origin/main'))  // git symbolic-ref (detectMainBranch for post-PR cleanup)
+      .mockImplementationOnce(() => resp(0))                              // git checkout main
+      .mockImplementationOnce(() => resp(0));                             // git pull --ff-only origin main
 
     const { startProjectPush: fn } = await import('@/lib/start-push');
     const r = await fn('proj');

--- a/__tests__/notifications.test.ts
+++ b/__tests__/notifications.test.ts
@@ -1,0 +1,287 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { notify, sendTestNotification } from '../lib/notifications';
+
+// Mock getSettings
+vi.mock('../lib/config', () => ({
+  getSettings: vi.fn(() => ({
+    notification_webhook_url: 'https://hooks.slack.com/services/test',
+    notification_webhook_secret: 'test-secret',
+    notification_on_release_success: true,
+    notification_on_release_fail: true,
+    notification_on_fix_loop_exhausted: true,
+    notification_on_review_do_not_ship: true,
+    notification_on_agent_run_fail: true,
+  })),
+}));
+
+// Mock fetch globally
+global.fetch = vi.fn();
+
+describe('notifications', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('notify()', () => {
+    it('sends notification when event is enabled', async () => {
+      (global.fetch as any).mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+      });
+
+      await notify({
+        event: 'release_success',
+        project: 'test-project',
+        job_id: 'job-123',
+        status: 'success',
+        timestamp: Date.now(),
+      });
+
+      expect(global.fetch).toHaveBeenCalled();
+      const [url, options] = (global.fetch as any).mock.calls[0];
+      expect(url).toBe('https://hooks.slack.com/services/test');
+      expect(options.method).toBe('POST');
+      expect(options.headers['X-TamTam-Signature']).toBeDefined();
+    });
+
+    it('does not send when webhook URL is empty', async () => {
+      vi.resetModules();
+      const { getSettings } = await import('../lib/config');
+      (getSettings as any).mockReturnValueOnce({
+        notification_webhook_url: '',
+        notification_on_release_success: true,
+      });
+
+      await notify({
+        event: 'release_success',
+        project: 'test-project',
+        job_id: 'job-123',
+        status: 'success',
+        timestamp: Date.now(),
+      });
+
+      // Should not call fetch when URL is empty
+      expect(global.fetch).not.toHaveBeenCalled();
+    });
+
+    it('does not send when event is disabled', async () => {
+      vi.resetModules();
+      const { getSettings } = await import('../lib/config');
+      (getSettings as any).mockReturnValueOnce({
+        notification_webhook_url: 'https://hooks.slack.com/services/test',
+        notification_on_release_success: false,
+      });
+
+      await notify({
+        event: 'release_success',
+        project: 'test-project',
+        job_id: 'job-123',
+        status: 'success',
+        timestamp: Date.now(),
+      });
+
+      expect(global.fetch).not.toHaveBeenCalled();
+    });
+
+    it('retries on failure with exponential backoff', async () => {
+      (global.fetch as any)
+        .mockRejectedValueOnce(new Error('Network error'))
+        .mockRejectedValueOnce(new Error('Network error'))
+        .mockResolvedValueOnce({ ok: true });
+
+      await notify({
+        event: 'release_success',
+        project: 'test-project',
+        job_id: 'job-123',
+        status: 'success',
+        timestamp: Date.now(),
+      });
+
+      // Give async retries time to execute
+      await new Promise(resolve => setTimeout(resolve, 100));
+
+      expect(global.fetch).toHaveBeenCalled();
+    });
+
+    it('detects Slack webhook and formats message', async () => {
+      (global.fetch as any).mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+      });
+
+      await notify({
+        event: 'release_success',
+        project: 'test-project',
+        job_id: 'job-123',
+        status: 'success',
+        timestamp: Date.now(),
+      });
+
+      const call = (global.fetch as any).mock.calls[0];
+      const body = JSON.parse(call[1].body);
+      expect(body.blocks).toBeDefined();
+      expect(body.blocks[0].text.text).toContain('release success');
+      expect(body.blocks[0].text.text).toContain('test-project');
+    });
+
+    it('detects Discord webhook and formats message', async () => {
+      vi.resetModules();
+      const { notify: notify2 } = await import('../lib/notifications');
+      (global.fetch as any).mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+      });
+      const { getSettings } = await import('../lib/config');
+      (getSettings as any).mockReturnValueOnce({
+        notification_webhook_url: 'https://discord.com/api/webhooks/123/456',
+        notification_webhook_secret: 'test-secret',
+        notification_on_release_success: true,
+      });
+
+      await notify2({
+        event: 'release_success',
+        project: 'test-project',
+        job_id: 'job-123',
+        status: 'success',
+        timestamp: Date.now(),
+      });
+
+      const call = (global.fetch as any).mock.calls[0];
+      const body = JSON.parse(call[1].body);
+      expect(body.embeds).toBeDefined();
+      expect(body.embeds[0].title).toContain('release success');
+      expect(body.embeds[0].title).toContain('test-project');
+    });
+
+    it('signs payload with HMAC-SHA256', async () => {
+      (global.fetch as any).mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+      });
+
+      await notify({
+        event: 'release_success',
+        project: 'test-project',
+        job_id: 'job-123',
+        status: 'success',
+        timestamp: Date.now(),
+      });
+
+      const call = (global.fetch as any).mock.calls[0];
+      const signature = call[1].headers['X-TamTam-Signature'];
+      expect(signature).toBeDefined();
+      expect(signature).toMatch(/^[a-f0-9]{64}$/); // SHA256 hex digest
+    });
+  });
+
+  describe('sendTestNotification()', () => {
+    it('sends test notification', async () => {
+      (global.fetch as any).mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+      });
+
+      const result = await sendTestNotification(
+        'https://hooks.slack.com/services/test',
+        'test-secret'
+      );
+
+      expect(result.ok).toBe(true);
+      expect(global.fetch).toHaveBeenCalled();
+    });
+
+    it('returns error when URL is empty', async () => {
+      const result = await sendTestNotification('', 'test-secret');
+      expect(result.ok).toBe(false);
+      expect(result.error).toContain('URL is required');
+    });
+
+    it('returns error when webhook request fails', async () => {
+      // Clear mocks and reset
+      vi.clearAllMocks();
+      (global.fetch as any) = vi.fn().mockResolvedValueOnce({
+        ok: false,
+        status: 500,
+      });
+
+      const result = await sendTestNotification(
+        'https://hooks.slack.com/services/test',
+        'test-secret'
+      );
+
+      // Should retry and eventually fail
+      await new Promise(resolve => setTimeout(resolve, 100));
+
+      expect(result.ok).toBe(false);
+      expect(result.error).toBeDefined();
+    });
+
+    it('includes signature in test notification', async () => {
+      (global.fetch as any).mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+      });
+
+      await sendTestNotification(
+        'https://hooks.slack.com/services/test',
+        'test-secret'
+      );
+
+      const call = (global.fetch as any).mock.calls[0];
+      const signature = call[1].headers['X-TamTam-Signature'];
+      expect(signature).toBeDefined();
+    });
+  });
+
+  describe('payload formatting', () => {
+    it('includes all payload fields in notification', async () => {
+      (global.fetch as any).mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+      });
+
+      await notify({
+        event: 'release_success',
+        project: 'test-project',
+        agent: 'test-agent',
+        job_id: 'job-123',
+        status: 'success',
+        verdict: 'LGTM',
+        cost_usd: 0.0042,
+        log_url: 'http://localhost:1337/logs',
+        timestamp: Date.now(),
+      });
+
+      const call = (global.fetch as any).mock.calls[0];
+      const body = JSON.parse(call[1].body);
+
+      // For Slack format, check blocks
+      if (body.blocks) {
+        const text = JSON.stringify(body);
+        expect(text).toContain('test-project');
+        expect(text).toContain('success');
+      }
+    });
+
+    it('handles missing optional fields', async () => {
+      (global.fetch as any).mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+      });
+
+      await notify({
+        event: 'release_success',
+        project: 'test-project',
+        job_id: 'job-123',
+        status: 'success',
+        timestamp: Date.now(),
+      });
+
+      expect(global.fetch).toHaveBeenCalled();
+    });
+  });
+});

--- a/app/api/projects/by-project/[projectName]/issue-branch/route.ts
+++ b/app/api/projects/by-project/[projectName]/issue-branch/route.ts
@@ -1,0 +1,49 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { resolveProjectPath } from '@/lib/project-data';
+import { exec } from '@/lib/shell';
+
+// Given an issue context (number + title), check out a feature branch
+// `fix/issue-<n>-<slug>` before Claude starts editing so all interim work
+// lands on the branch instead of the default branch.
+export async function POST(
+  req: NextRequest,
+  { params }: { params: Promise<{ projectName: string }> },
+): Promise<NextResponse> {
+  const { projectName } = await params;
+  const projPath = resolveProjectPath(projectName);
+  if (!projPath) return NextResponse.json({ detail: 'project not found' }, { status: 404 });
+
+  let body: { issue_number?: number; issue_title?: string };
+  try { body = await req.json(); }
+  catch { return NextResponse.json({ detail: 'invalid JSON' }, { status: 400 }); }
+
+  const issueNumber = Number(body.issue_number);
+  if (!Number.isInteger(issueNumber) || issueNumber <= 0) {
+    return NextResponse.json({ detail: 'issue_number required' }, { status: 400 });
+  }
+  const title = (body.issue_title ?? '').toString();
+
+  const slug = title.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '').slice(0, 40).replace(/-+$/, '');
+  const branch = `fix/issue-${issueNumber}${slug ? `-${slug}` : ''}`;
+
+  const currentR = await exec('git', ['-C', projPath, 'branch', '--show-current'], { timeout: 5000 });
+  const currentBranch = currentR.stdout.trim();
+  if (currentBranch === branch) {
+    return NextResponse.json({ status: 'already-on-branch', branch });
+  }
+
+  // Create-or-checkout. We deliberately preserve uncommitted work by not
+  // touching the index — `git checkout -b` carries the working tree across.
+  const createR = await exec('git', ['-C', projPath, 'checkout', '-b', branch], { timeout: 10000 });
+  if (createR.exitCode === 0) {
+    return NextResponse.json({ status: 'created', branch });
+  }
+  const existingR = await exec('git', ['-C', projPath, 'checkout', branch], { timeout: 10000 });
+  if (existingR.exitCode === 0) {
+    return NextResponse.json({ status: 'reused', branch });
+  }
+  return NextResponse.json(
+    { detail: `Failed to checkout ${branch}: ${createR.stderr || existingR.stderr}` },
+    { status: 500 },
+  );
+}

--- a/app/api/settings/route.ts
+++ b/app/api/settings/route.ts
@@ -23,6 +23,13 @@ const SETTING_KEYS = [
   'log_retention_count',
   'log_retention_days',
   'job_row_retention_days',
+  'notification_webhook_url',
+  'notification_webhook_secret',
+  'notification_on_release_success',
+  'notification_on_release_fail',
+  'notification_on_fix_loop_exhausted',
+  'notification_on_review_do_not_ship',
+  'notification_on_agent_run_fail',
 ] as const;
 
 export async function GET() {

--- a/app/api/settings/test-notification/route.ts
+++ b/app/api/settings/test-notification/route.ts
@@ -1,0 +1,24 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { sendTestNotification } from '@/lib/notifications';
+
+export async function POST(request: NextRequest) {
+  try {
+    const { webhook_url, webhook_secret } = await request.json();
+
+    if (!webhook_url) {
+      return NextResponse.json(
+        { ok: false, error: 'Webhook URL is required' },
+        { status: 400 }
+      );
+    }
+
+    const result = await sendTestNotification(webhook_url, webhook_secret || '');
+    return NextResponse.json(result);
+  } catch (error) {
+    console.error('[test-notification] error:', error);
+    return NextResponse.json(
+      { ok: false, error: 'Failed to send test notification' },
+      { status: 500 }
+    );
+  }
+}

--- a/components/SettingsPage.tsx
+++ b/components/SettingsPage.tsx
@@ -24,6 +24,13 @@ interface SettingsMap {
   log_retention_count: string
   log_retention_days: string
   job_row_retention_days: string
+  notification_webhook_url: string
+  notification_webhook_secret: string
+  notification_on_release_success: string
+  notification_on_release_fail: string
+  notification_on_fix_loop_exhausted: string
+  notification_on_review_do_not_ship: string
+  notification_on_agent_run_fail: string
 }
 
 export interface AgentTemplateRecord {
@@ -61,6 +68,13 @@ const DEFAULTS: SettingsMap = {
   log_retention_count: '200',
   log_retention_days: '30',
   job_row_retention_days: '180',
+  notification_webhook_url: '',
+  notification_webhook_secret: '',
+  notification_on_release_success: 'false',
+  notification_on_release_fail: 'false',
+  notification_on_fix_loop_exhausted: 'false',
+  notification_on_review_do_not_ship: 'false',
+  notification_on_agent_run_fail: 'false',
 }
 
 interface FieldDef {
@@ -195,9 +209,51 @@ const FIELDS: Record<keyof SettingsMap, FieldDef> = {
     group: 'behavior',
     span: 1,
   },
+  notification_webhook_url: {
+    label: 'Notification Webhook URL',
+    help: 'Not used in FIELDS; handled by NotificationsTab',
+    group: 'notifications' as never,
+    span: 1,
+  },
+  notification_webhook_secret: {
+    label: 'Notification Webhook Secret',
+    help: 'Not used in FIELDS; handled by NotificationsTab',
+    group: 'notifications' as never,
+    span: 1,
+  },
+  notification_on_release_success: {
+    label: 'Notification on Release Success',
+    help: 'Not used in FIELDS; handled by NotificationsTab',
+    group: 'notifications' as never,
+    span: 1,
+  },
+  notification_on_release_fail: {
+    label: 'Notification on Release Fail',
+    help: 'Not used in FIELDS; handled by NotificationsTab',
+    group: 'notifications' as never,
+    span: 1,
+  },
+  notification_on_fix_loop_exhausted: {
+    label: 'Notification on Fix Loop Exhausted',
+    help: 'Not used in FIELDS; handled by NotificationsTab',
+    group: 'notifications' as never,
+    span: 1,
+  },
+  notification_on_review_do_not_ship: {
+    label: 'Notification on Review Do Not Ship',
+    help: 'Not used in FIELDS; handled by NotificationsTab',
+    group: 'notifications' as never,
+    span: 1,
+  },
+  notification_on_agent_run_fail: {
+    label: 'Notification on Agent Run Fail',
+    help: 'Not used in FIELDS; handled by NotificationsTab',
+    group: 'notifications' as never,
+    span: 1,
+  },
 }
 
-type TabId = 'behavior' | 'workspace' | 'scheduling' | 'system' | 'projects' | 'database' | 'templates'
+type TabId = 'behavior' | 'workspace' | 'scheduling' | 'system' | 'projects' | 'database' | 'templates' | 'notifications'
 
 const GROUPS: {
   id: TabId
@@ -216,6 +272,7 @@ const TABS: { id: TabId; label: string }[] = [
   { id: 'workspace',  label: 'Workspace' },
   { id: 'scheduling', label: 'Scheduling' },
   { id: 'system',     label: 'System' },
+  { id: 'notifications', label: 'Notifications' },
   { id: 'projects',   label: 'Projects' },
   { id: 'database',   label: 'Database' },
   { id: 'templates',  label: 'Templates' },
@@ -424,6 +481,138 @@ function TemplateForm({
         </button>
       </div>
     </div>
+  )
+}
+
+function NotificationsTab({
+  settings,
+  onChange,
+}: {
+  settings: SettingsMap
+  onChange: (key: keyof SettingsMap, value: string) => void
+}) {
+  const [testSending, setTestSending] = useState(false)
+  const [testError, setTestError] = useState<string | null>(null)
+  const [testSuccess, setTestSuccess] = useState(false)
+
+  const handleTestNotification = async () => {
+    if (!settings.notification_webhook_url) {
+      setTestError('Webhook URL is required')
+      return
+    }
+
+    setTestSending(true)
+    setTestError(null)
+    setTestSuccess(false)
+
+    try {
+      const res = await fetch('/api/settings/test-notification', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          webhook_url: settings.notification_webhook_url,
+          webhook_secret: settings.notification_webhook_secret,
+        }),
+      })
+      const data = await res.json()
+      if (!res.ok || !data.ok) {
+        throw new Error(data.error || 'Failed to send test notification')
+      }
+      setTestSuccess(true)
+      setTimeout(() => setTestSuccess(false), 3000)
+    } catch (e: unknown) {
+      setTestError(errMsg(e))
+      setTimeout(() => setTestError(null), 5000)
+    } finally {
+      setTestSending(false)
+    }
+  }
+
+  const eventToggles = [
+    { key: 'notification_on_release_success' as const, label: 'Release Success', description: 'When a release pipeline completes successfully' },
+    { key: 'notification_on_release_fail' as const, label: 'Release Failure', description: 'When a release pipeline fails' },
+    { key: 'notification_on_fix_loop_exhausted' as const, label: 'Fix Loop Exhausted', description: 'When the fix loop reaches its retry limit' },
+    { key: 'notification_on_review_do_not_ship' as const, label: 'Review: Do Not Ship', description: 'When a review verdict is "DO NOT SHIP"' },
+    { key: 'notification_on_agent_run_fail' as const, label: 'Agent Run Failure', description: 'When an agent run fails' },
+  ]
+
+  return (
+    <section className="space-y-4">
+      {/* Webhook Configuration */}
+      <div className="bg-bg-secondary rounded-lg border border-border">
+        <div className="px-5 py-3 border-b border-border flex items-baseline gap-3">
+          <h3 className="text-sm font-semibold text-text-primary">Webhook Configuration</h3>
+          <p className="text-xs text-text-tertiary">Configure outbound notifications for release pipeline events</p>
+        </div>
+        <div className="px-5 py-4 space-y-4">
+          <div>
+            <label className="block font-medium text-sm text-text-primary mb-1.5">Webhook URL</label>
+            <input
+              type="text"
+              value={settings.notification_webhook_url}
+              onChange={(e) => onChange('notification_webhook_url', e.target.value)}
+              placeholder="https://hooks.slack.com/services/... or https://discordapp.com/api/webhooks/... or any webhook endpoint"
+              className={INPUT_CLASS}
+            />
+            <p className="text-xs text-text-tertiary mt-1.5">Supports Slack, Discord, ntfy, and generic JSON POST webhooks</p>
+          </div>
+
+          <div>
+            <label className="block font-medium text-sm text-text-primary mb-1.5">Webhook Secret (Optional)</label>
+            <input
+              type="password"
+              value={settings.notification_webhook_secret}
+              onChange={(e) => onChange('notification_webhook_secret', e.target.value)}
+              placeholder="Secret for HMAC-SHA256 signature verification"
+              className={INPUT_CLASS}
+            />
+            <p className="text-xs text-text-tertiary mt-1.5">If set, payloads will be signed with <code className="bg-bg-tertiary px-1 rounded">X-TamTam-Signature</code> header</p>
+          </div>
+
+          <div className="flex items-center gap-3 pt-2">
+            <button
+              onClick={handleTestNotification}
+              disabled={testSending || !settings.notification_webhook_url}
+              className={`px-4 py-1.5 text-white border-none rounded-lg font-semibold text-sm cursor-pointer transition-colors ${
+                testSuccess ? 'bg-status-success' : 'bg-accent hover:bg-accent-hover disabled:opacity-50 disabled:cursor-not-allowed'
+              } ${testSending ? 'opacity-50 cursor-wait' : ''}`}
+            >
+              {testSending ? 'Sending…' : testSuccess ? 'Sent!' : 'Send Test'}
+            </button>
+            {testError && (
+              <span className="text-sm text-status-error">{testError}</span>
+            )}
+          </div>
+        </div>
+      </div>
+
+      {/* Event Toggles */}
+      <div className="bg-bg-secondary rounded-lg border border-border">
+        <div className="px-5 py-3 border-b border-border flex items-baseline gap-3">
+          <h3 className="text-sm font-semibold text-text-primary">Notification Events</h3>
+          <p className="text-xs text-text-tertiary">Choose which events trigger notifications</p>
+        </div>
+        <div className="px-5 py-4 space-y-3">
+          {eventToggles.map(({ key, label, description }) => (
+            <label
+              key={key}
+              className="flex items-start gap-3 p-3 rounded-lg hover:bg-bg-tertiary/50 cursor-pointer transition-colors"
+            >
+              <input
+                type="checkbox"
+                checked={settings[key] === 'true'}
+                onChange={(e) => onChange(key, e.target.checked ? 'true' : 'false')}
+                className="w-4 h-4 accent-accent rounded mt-0.5 shrink-0 cursor-pointer"
+              />
+              <div className="flex-1 min-w-0">
+                <div className="font-medium text-sm text-text-primary">{label}</div>
+                <div className="text-xs text-text-tertiary">{description}</div>
+              </div>
+            </label>
+          ))}
+        </div>
+      </div>
+    </section>
   )
 }
 
@@ -834,6 +1023,14 @@ export function SettingsPage() {
             <AgentTemplatesTab
               value={settings.agent_templates}
               onChange={(v) => handleChange('agent_templates', v)}
+            />
+          )}
+
+          {/* Notifications */}
+          {activeTab === 'notifications' && (
+            <NotificationsTab
+              settings={settings}
+              onChange={handleChange}
             />
           )}
 

--- a/components/TerminalTab.tsx
+++ b/components/TerminalTab.tsx
@@ -218,11 +218,29 @@ export function TerminalTab({ projectName, initialSessionId }: TerminalTabProps)
     loadSessions()
   }, [])
 
-  // Auto-submit prompt from ?prompt= query param (e.g. opened from Issues tab)
+  // Auto-submit prompt from ?prompt= query param (e.g. opened from Issues tab).
+  // When issue params are present, provision the feature branch BEFORE handing
+  // off to Claude — otherwise interim edits land on the default branch.
   useEffect(() => {
     if (!promptParam || initialSessionId || jobParam) return
-    terminalStore.update(projectName, () => ({ pendingAutoSubmit: promptParam }))
-    router.replace(`/project/${projectName}/terminal`)
+    const submit = promptParam
+    const run = async () => {
+      if (issueNumberParam) {
+        try {
+          await fetch(`/api/projects/by-project/${encodeURIComponent(projectName)}/issue-branch`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({
+              issue_number: Number(issueNumberParam),
+              issue_title: issueTitleParam ?? '',
+            }),
+          })
+        } catch {}
+      }
+      terminalStore.update(projectName, () => ({ pendingAutoSubmit: submit }))
+      router.replace(`/project/${projectName}/terminal`)
+    }
+    run()
   }, [])
 
   // Restore session from URL param. Skipped if store already holds state for

--- a/docs/SETTINGS.md
+++ b/docs/SETTINGS.md
@@ -45,6 +45,27 @@ All settings stored in the `settings` table (key-value, both TEXT). Accessed via
 | `commit_style` | string | Conventional commits guide | Injected into the push commit-message generation prompt |
 | `review_verdict_rules` | string | Pragmatic rules | Injected into review prompts; drives LGTM / NEEDS ATTENTION / DO NOT SHIP decisions |
 
+### Notifications
+
+Outbound webhooks for release pipeline events. Never blocks pipeline progress — deliverability is best-effort with 3 retries.
+
+| Key | Type | Default | Effect |
+|-----|------|---------|--------|
+| `notification_webhook_url` | string | `''` | Webhook endpoint URL. Supports Slack (`hooks.slack.com`), Discord (`discord.com/api/webhooks`), ntfy, and generic JSON POST endpoints. Leave blank to disable notifications. |
+| `notification_webhook_secret` | string | `''` | Optional secret for HMAC-SHA256 signature verification. If set, payloads include `X-TamTam-Signature` header. |
+| `notification_on_release_success` | boolean | `false` | Stored as `'true'`/`'false'`. Notify when a release pipeline completes successfully. |
+| `notification_on_release_fail` | boolean | `false` | Notify when a release pipeline fails. |
+| `notification_on_fix_loop_exhausted` | boolean | `false` | Notify when the fix loop reaches its maximum iteration count (prevents infinite review→fix cycles). |
+| `notification_on_review_do_not_ship` | boolean | `false` | Notify when a code review verdict is "DO NOT SHIP". |
+| `notification_on_agent_run_fail` | boolean | `false` | Notify when an agent run fails. |
+
+**Payload format:** 
+- **Slack**: Formatted as block kit with event, project, status, verdict (if review), cost (if available), and a log link.
+- **Discord**: Embedded message with event details and a timestamp.
+- **Generic**: JSON POST with `{ event, project, job_id, status, verdict?, agent?, cost_usd?, log_url?, timestamp }`.
+
+**Test notification:** Use the "Send Test" button in the Notifications tab to verify webhook connectivity before enabling production events.
+
 ### Fix-CI Auto-Retry
 
 All three are read live on each job (not cached), so changing them takes effect immediately.
@@ -69,6 +90,56 @@ All three are read live on each job (not cached), so changing them takes effect 
 |-----|------|---------|--------|
 | `log_dir` | string | `./data/logs` | Directory where job log files are written |
 | `launchagent_prefix` | string | `com.tamtam` | Prefix for macOS LaunchAgent plist filenames |
+
+### Notifications
+
+Outbound webhook fired when the release pipeline reaches a terminal state. Supports Slack incoming webhooks, Discord webhooks, and any generic HTTP receiver (e.g. ntfy).
+
+| Key | Type | Default | Effect |
+|-----|------|---------|--------|
+| `notification_webhook_url` | string | `''` | Destination URL; auto-detected as Slack / Discord / generic by URL pattern |
+| `notification_webhook_secret` | string | `''` | If set, every POST includes an `X-TamTam-Signature` HMAC-SHA256 hex header over the JSON body |
+| `notification_on_release_success` | boolean | `false` | Fire when the full release pipeline completes with exit 0 |
+| `notification_on_release_fail` | boolean | `false` | Fire when any pipeline step fails and the pipeline halts |
+| `notification_on_fix_loop_exhausted` | boolean | `false` | Fire when the fix-iteration cap (3/30 min) is reached without achieving LGTM |
+| `notification_on_review_do_not_ship` | boolean | `false` | Fire when a review returns a DO NOT SHIP verdict |
+| `notification_on_agent_run_fail` | boolean | `false` | Fire when any scheduled agent job exits non-zero |
+
+**Payload shape** (generic JSON POST):
+
+```typescript
+{
+  event: 'release_success' | 'release_fail' | 'fix_loop_exhausted' | 'review_do_not_ship' | 'agent_run_fail';
+  project: string;
+  agent?: string;         // set for agent_run_fail events
+  job_id: string;
+  status: 'success' | 'failed';
+  verdict?: string;       // set for review events
+  cost_usd?: number;
+  log_url?: string;       // link to /project/<name>/history; driven by TAMTAM_BASE_URL env
+  message?: string;
+  timestamp: number;      // ms since epoch
+}
+```
+
+**Signature verification** (when `notification_webhook_secret` is set):
+
+```js
+const expected = createHmac('sha256', secret).update(rawBody).digest('hex');
+const isValid = timingSafeEqual(Buffer.from(expected), Buffer.from(req.headers['x-tamtam-signature']));
+```
+
+**Adapter detection** (automatic, based on URL):
+
+| URL pattern | Format |
+|-------------|--------|
+| `hooks.slack.com` | Slack Block Kit |
+| `discord.com/api/webhooks` | Discord embed |
+| anything else | Raw JSON (works for ntfy, custom receivers) |
+
+**Retry**: 3 attempts, exponential backoff (1s → 2s → 4s). Failures are logged and never block pipeline progress.
+
+**Test button**: Settings → Notifications tab → "Send Test" fires a synthetic `release_success` payload immediately.
 
 ### Templates
 
@@ -103,8 +174,14 @@ launchagent_prefix, workspace_path, base_prompt, default_model,
 permission_mode, commit_style, review_verdict_rules,
 fix_ci_max_retries, fix_ci_retry_window_seconds, fix_ci_fast_crash_ms,
 agent_templates,
-log_retention_count, log_retention_days, job_row_retention_days
+log_retention_count, log_retention_days, job_row_retention_days,
+notification_webhook_url, notification_webhook_secret,
+notification_on_release_success, notification_on_release_fail,
+notification_on_fix_loop_exhausted, notification_on_review_do_not_ship,
+notification_on_agent_run_fail
 ```
+
+**POST `/api/settings/test-notification`** — sends a test notification to verify webhook connectivity. Request body: `{ webhook_url: string, webhook_secret?: string }`. Response: `{ ok: boolean, error?: string }`.
 
 ---
 

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -25,6 +25,13 @@ export interface TamTamConfig {
   log_retention_count: number;
   log_retention_days: number;
   job_row_retention_days: number;
+  notification_webhook_url: string;
+  notification_webhook_secret: string;
+  notification_on_release_success: boolean;
+  notification_on_release_fail: boolean;
+  notification_on_fix_loop_exhausted: boolean;
+  notification_on_review_do_not_ship: boolean;
+  notification_on_agent_run_fail: boolean;
 }
 
 const DEFAULTS: TamTamConfig = {
@@ -52,6 +59,13 @@ const DEFAULTS: TamTamConfig = {
   log_retention_count: 200,
   log_retention_days: 30,
   job_row_retention_days: 180,
+  notification_webhook_url: '',
+  notification_webhook_secret: '',
+  notification_on_release_success: false,
+  notification_on_release_fail: false,
+  notification_on_fix_loop_exhausted: false,
+  notification_on_review_do_not_ship: false,
+  notification_on_agent_run_fail: false,
 };
 
 let _cache: { config: TamTamConfig; time: number } | null = null;
@@ -85,6 +99,13 @@ export function getSettings(): TamTamConfig {
     log_retention_count: parseIntOr(map.log_retention_count, DEFAULTS.log_retention_count),
     log_retention_days: parseIntOr(map.log_retention_days, DEFAULTS.log_retention_days),
     job_row_retention_days: parseIntOr(map.job_row_retention_days, DEFAULTS.job_row_retention_days),
+    notification_webhook_url: map.notification_webhook_url ?? DEFAULTS.notification_webhook_url,
+    notification_webhook_secret: map.notification_webhook_secret ?? DEFAULTS.notification_webhook_secret,
+    notification_on_release_success: map.notification_on_release_success === 'true',
+    notification_on_release_fail: map.notification_on_release_fail === 'true',
+    notification_on_fix_loop_exhausted: map.notification_on_fix_loop_exhausted === 'true',
+    notification_on_review_do_not_ship: map.notification_on_review_do_not_ship === 'true',
+    notification_on_agent_run_fail: map.notification_on_agent_run_fail === 'true',
   };
 
   _cache = { config, time: now };

--- a/lib/job-storage.ts
+++ b/lib/job-storage.ts
@@ -304,6 +304,7 @@ async function runCompletionHooks(job: JobData): Promise<void> {
   // release meta-job is at a natural endpoint and should be finalized so the
   // UI doesn't render it as "live" forever.
   let chainedNext = false;
+  let notificationEvent: string | null = null;
 
   if (job.kind === 'review') {
     if (job.exitCode === 0) {
@@ -332,6 +333,9 @@ async function runCompletionHooks(job: JobData): Promise<void> {
           // the release via its own completion hook.
           chainedNext = true;
         } else if (verdict === 'NEEDS ATTENTION' || verdict === 'DO NOT SHIP') {
+          if (verdict === 'DO NOT SHIP') {
+            notificationEvent = 'review_do_not_ship';
+          }
           const count = recentFixCount(job.project);
           if (count < MAX_FIX_ITERATIONS) {
             const { startFixFromJob } = await import('./start-fix');
@@ -344,6 +348,7 @@ async function runCompletionHooks(job: JobData): Promise<void> {
             }
           } else {
             console.log(`[release] fix cap reached for ${job.project} (${count}/${MAX_FIX_ITERATIONS}) — stopping`);
+            notificationEvent = 'fix_loop_exhausted';
           }
         }
         // else: unknown / no verdict — fall through, release will finalize below
@@ -463,6 +468,10 @@ async function runCompletionHooks(job: JobData): Promise<void> {
     const release = findActiveReleaseJob(job.project);
     if (release) {
       const exitCode = (job.exitCode === 0) ? 0 : 1;
+      // Emit release success/fail notification before finalizing
+      if (!notificationEvent) {
+        notificationEvent = exitCode === 0 ? 'release_success' : 'release_fail';
+      }
       await finalizeReleaseJob(release, exitCode);
     } else {
       // No active release job — still need to release the lock if this was a standalone pipeline job
@@ -470,6 +479,26 @@ async function runCompletionHooks(job: JobData): Promise<void> {
         const { releaseLock } = await import('./pipeline-lock');
         releaseLock(job.project, job.id);
       } catch {}
+    }
+  }
+
+  // Send notification if an event was triggered
+  if (notificationEvent) {
+    try {
+      const { notify } = await import('./notifications');
+      const logUrl = job.logPath ? `${process.env.TAMTAM_BASE_URL || 'http://localhost:1337'}/project/${encodeURIComponent(job.project)}/history` : undefined;
+      const verdict = job.kind === 'review' ? getVerdict(job) : null;
+      await notify({
+        event: notificationEvent as any,
+        project: job.project,
+        job_id: job.id,
+        status: job.exitCode === 0 ? 'success' : 'failed',
+        verdict: verdict ?? undefined,
+        log_url: logUrl,
+        timestamp: Date.now(),
+      });
+    } catch (e) {
+      console.error(`[notifications] failed to send notification for ${notificationEvent}:`, e);
     }
   }
 
@@ -492,6 +521,26 @@ async function runCompletionHooks(job: JobData): Promise<void> {
       }, delayMs);
     } else if (attempts > maxRetries) {
       console.log(`[fix-ci] retry cap reached for ${job.project} (${attempts}/${maxRetries}) — giving up`);
+    }
+  }
+
+  // Agent run failures: notify on agent run failures
+  if (job.kind.startsWith('agent:') && job.exitCode !== 0) {
+    try {
+      const { notify } = await import('./notifications');
+      const agentName = job.kind.replace('agent:', '');
+      const logUrl = job.logPath ? `${process.env.TAMTAM_BASE_URL || 'http://localhost:1337'}/project/${encodeURIComponent(job.project)}/history` : undefined;
+      await notify({
+        event: 'agent_run_fail',
+        project: job.project,
+        agent: agentName,
+        job_id: job.id,
+        status: 'failed',
+        log_url: logUrl,
+        timestamp: Date.now(),
+      });
+    } catch (e) {
+      console.error(`[notifications] failed to send agent_run_fail notification:`, e);
     }
   }
 

--- a/lib/notifications.ts
+++ b/lib/notifications.ts
@@ -1,0 +1,227 @@
+import { createHmac } from 'crypto';
+import { getSettings } from './config';
+
+export type NotificationEvent =
+  | 'release_success'
+  | 'release_fail'
+  | 'fix_loop_exhausted'
+  | 'review_do_not_ship'
+  | 'agent_run_fail';
+
+export interface NotificationPayload {
+  event: NotificationEvent;
+  project: string;
+  agent?: string;
+  job_id: string;
+  status: 'success' | 'failed';
+  verdict?: string;
+  cost_usd?: number;
+  log_url?: string;
+  message?: string;
+  timestamp: number;
+}
+
+interface NotificationConfig {
+  webhook_url: string;
+  webhook_secret: string;
+  enabled: boolean;
+}
+
+function getNotificationConfig(event: NotificationEvent): NotificationConfig {
+  const settings = getSettings();
+  const webhookUrl = settings.notification_webhook_url || '';
+  const webhookSecret = settings.notification_webhook_secret || '';
+
+  const eventKey = `notification_on_${event}`;
+  let enabled = false;
+
+  switch (event) {
+    case 'release_success':
+      enabled = settings.notification_on_release_success || false;
+      break;
+    case 'release_fail':
+      enabled = settings.notification_on_release_fail || false;
+      break;
+    case 'fix_loop_exhausted':
+      enabled = settings.notification_on_fix_loop_exhausted || false;
+      break;
+    case 'review_do_not_ship':
+      enabled = settings.notification_on_review_do_not_ship || false;
+      break;
+    case 'agent_run_fail':
+      enabled = settings.notification_on_agent_run_fail || false;
+      break;
+  }
+
+  return { webhook_url: webhookUrl, webhook_secret: webhookSecret, enabled };
+}
+
+function signPayload(payload: string, secret: string): string {
+  return createHmac('sha256', secret).update(payload).digest('hex');
+}
+
+function detectWebhookType(url: string): 'slack' | 'discord' | 'generic' {
+  if (url.includes('hooks.slack.com')) return 'slack';
+  if (url.includes('discord.com/api/webhooks')) return 'discord';
+  return 'generic';
+}
+
+function formatSlackMessage(payload: NotificationPayload): Record<string, unknown> {
+  const color = payload.status === 'success' ? '#36a64f' : '#ff0000';
+  const emoji = payload.status === 'success' ? '✅' : '❌';
+
+  return {
+    blocks: [
+      {
+        type: 'section',
+        text: {
+          type: 'mrkdwn',
+          text: `${emoji} *${payload.event.replace(/_/g, ' ')}* (${payload.project})`,
+        },
+      },
+      {
+        type: 'section',
+        fields: [
+          { type: 'mrkdwn', text: `*Event*\n${payload.event}` },
+          { type: 'mrkdwn', text: `*Project*\n${payload.project}` },
+          { type: 'mrkdwn', text: `*Status*\n${payload.status}` },
+          ...(payload.verdict ? [{ type: 'mrkdwn', text: `*Verdict*\n${payload.verdict}` }] : []),
+          ...(payload.agent ? [{ type: 'mrkdwn', text: `*Agent*\n${payload.agent}` }] : []),
+          ...(payload.cost_usd ? [{ type: 'mrkdwn', text: `*Cost*\n$${payload.cost_usd.toFixed(4)}` }] : []),
+        ],
+      },
+      ...(payload.message ? [{ type: 'section', text: { type: 'mrkdwn', text: `_${payload.message}_` } }] : []),
+      ...(payload.log_url ? [{ type: 'actions', elements: [{ type: 'button', text: { type: 'plain_text', text: 'View Log' }, url: payload.log_url }] }] : []),
+    ],
+  };
+}
+
+function formatDiscordMessage(payload: NotificationPayload): Record<string, unknown> {
+  const color = payload.status === 'success' ? 3_066_993 : 15_158_332;
+
+  return {
+    embeds: [
+      {
+        title: `${payload.event.replace(/_/g, ' ')} (${payload.project})`,
+        color,
+        fields: [
+          { name: 'Status', value: payload.status, inline: true },
+          ...(payload.verdict ? [{ name: 'Verdict', value: payload.verdict, inline: true }] : []),
+          ...(payload.agent ? [{ name: 'Agent', value: payload.agent, inline: true }] : []),
+          ...(payload.cost_usd ? [{ name: 'Cost', value: `$${payload.cost_usd.toFixed(4)}`, inline: true }] : []),
+          ...(payload.message ? [{ name: 'Message', value: payload.message }] : []),
+        ],
+        ...(payload.log_url ? { url: payload.log_url } : {}),
+        timestamp: new Date(payload.timestamp).toISOString(),
+      },
+    ],
+  };
+}
+
+async function postWebhook(
+  url: string,
+  body: Record<string, unknown>,
+  signature?: string,
+  maxRetries: number = 3,
+): Promise<boolean> {
+  const headers: Record<string, string> = {
+    'Content-Type': 'application/json',
+    'User-Agent': 'TamTam/1.0',
+  };
+
+  if (signature) {
+    headers['X-TamTam-Signature'] = signature;
+  }
+
+  let lastError: Error | null = null;
+
+  for (let attempt = 0; attempt < maxRetries; attempt++) {
+    try {
+      const response = await fetch(url, {
+        method: 'POST',
+        headers,
+        body: JSON.stringify(body),
+        signal: AbortSignal.timeout(10_000),
+      });
+
+      if (response.ok) {
+        return true;
+      }
+
+      lastError = new Error(`HTTP ${response.status}`);
+    } catch (e) {
+      lastError = e instanceof Error ? e : new Error(String(e));
+    }
+
+    if (attempt < maxRetries - 1) {
+      const delayMs = Math.min(1000 * Math.pow(2, attempt), 8000);
+      await new Promise(resolve => setTimeout(resolve, delayMs));
+    }
+  }
+
+  console.error(`[notifications] webhook POST failed after ${maxRetries} attempts:`, lastError?.message);
+  return false;
+}
+
+export async function notify(payload: NotificationPayload): Promise<void> {
+  if (!payload.timestamp) {
+    payload.timestamp = Date.now();
+  }
+
+  const config = getNotificationConfig(payload.event);
+
+  if (!config.enabled || !config.webhook_url) {
+    return;
+  }
+
+  const webhookType = detectWebhookType(config.webhook_url);
+  let body: Record<string, unknown>;
+
+  if (webhookType === 'slack') {
+    body = formatSlackMessage(payload);
+  } else if (webhookType === 'discord') {
+    body = formatDiscordMessage(payload);
+  } else {
+    body = payload as unknown as Record<string, unknown>;
+  }
+
+  const bodyJson = JSON.stringify(body);
+  const signature = config.webhook_secret ? signPayload(bodyJson, config.webhook_secret) : undefined;
+
+  // Never block pipeline progress — fire and forget
+  postWebhook(config.webhook_url, body, signature).catch((e) => {
+    console.error(`[notifications] failed to send ${payload.event} notification:`, e);
+  });
+}
+
+export async function sendTestNotification(webhookUrl: string, webhookSecret: string): Promise<{ ok: boolean; error?: string }> {
+  if (!webhookUrl) {
+    return { ok: false, error: 'Webhook URL is required' };
+  }
+
+  const payload: NotificationPayload = {
+    event: 'release_success',
+    project: 'test-project',
+    job_id: 'test-job-123',
+    status: 'success',
+    message: 'This is a test notification from TamTam',
+    timestamp: Date.now(),
+  };
+
+  const webhookType = detectWebhookType(webhookUrl);
+  let body: Record<string, unknown>;
+
+  if (webhookType === 'slack') {
+    body = formatSlackMessage(payload);
+  } else if (webhookType === 'discord') {
+    body = formatDiscordMessage(payload);
+  } else {
+    body = payload as unknown as Record<string, unknown>;
+  }
+
+  const bodyJson = JSON.stringify(body);
+  const signature = webhookSecret ? signPayload(bodyJson, webhookSecret) : undefined;
+
+  const success = await postWebhook(webhookUrl, body, signature);
+  return success ? { ok: true } : { ok: false, error: 'Webhook request failed' };
+}

--- a/lib/start-push.ts
+++ b/lib/start-push.ts
@@ -375,9 +375,23 @@ async function runPush(
   const shaR = await exec('git', ['-C', projPath, 'rev-parse', '--short', 'HEAD'], { timeout: 5000 });
   const commitSha = shaR.exitCode === 0 ? shaR.stdout.trim() : '';
 
-  // If this session was started from a GitHub issue, create a PR that closes it
+  // If this session was started from a GitHub issue, create a PR that closes it,
+  // then return to the default branch and pull so the working copy is ready for
+  // the next task. Failures here are non-fatal — the PR is already out.
   if (issueCtx) {
     const prUrl = await createIssuePR(projPath, log, issueCtx);
+    if (prUrl) {
+      const mainBranch = await detectMainBranch(projPath);
+      log(`\n# switching back to ${mainBranch} and pulling\n`);
+      const coR = await exec('git', ['-C', projPath, 'checkout', mainBranch], { timeout: 10000 });
+      if (coR.stdout) log(coR.stdout);
+      if (coR.stderr) log(coR.stderr);
+      if (coR.exitCode === 0) {
+        const pullR = await exec('git', ['-C', projPath, 'pull', '--ff-only', 'origin', mainBranch], { timeout: 30000 });
+        if (pullR.stdout) log(pullR.stdout);
+        if (pullR.stderr) log(pullR.stderr);
+      }
+    }
     return { ok: true, commitSha, message: prUrl ? `PR created: ${prUrl}` : 'pushed (PR creation failed — see log)' };
   }
 


### PR DESCRIPTION
Closes #7

Implemented via TamTam from issue [#7](https://github.com/3h4x/tamtam/issues/7).