### PR TITLE
feat: track token usage and cost per run with agent breakdown

### DIFF
--- a/__tests__/api/stats-usage.test.ts
+++ b/__tests__/api/stats-usage.test.ts
@@ -42,6 +42,7 @@ describe('GET /api/stats/usage', () => {
     expect(res.status).toBe(200);
     const data = await res.json();
     expect(data.projects).toEqual([]);
+    expect(data.agents).toEqual([]);
     expect(data.totals.runs).toBe(0);
     expect(data.totals.costUsd).toBe(0);
     expect(data.window).toBe('30d');
@@ -117,6 +118,23 @@ describe('GET /api/stats/usage', () => {
     const res = await GET(new NextRequest('http://localhost/api/stats/usage?window=all'));
     const data = await res.json();
     expect(data.projects[0].lastRunAt).toBe(2000);
+  });
+
+  it('returns agents breakdown grouped by kind sorted by cost', async () => {
+    listJobsMock.mockReturnValue([
+      makeJob({ id: 'a', project: 'p1', kind: 'review', outputTokens: 500_000 }),
+      makeJob({ id: 'b', project: 'p1', kind: 'review', outputTokens: 100_000 }),
+      makeJob({ id: 'c', project: 'p2', kind: 'fix', outputTokens: 200_000 }),
+      makeJob({ id: 'd', project: 'p1', kind: 'agent:cto', outputTokens: 1_000_000 }),
+    ]);
+    const res = await GET(new NextRequest('http://localhost/api/stats/usage?window=all'));
+    const data = await res.json();
+    expect(data.agents.length).toBe(3);
+    const kinds = data.agents.map((r: any) => r.kind);
+    expect(kinds[0]).toBe('agent:cto');
+    const reviewRow = data.agents.find((r: any) => r.kind === 'review');
+    expect(reviewRow.runs).toBe(2);
+    expect(reviewRow.outputTokens).toBe(600_000);
   });
 
   it('treats null token fields as zero', async () => {

--- a/__tests__/lib/claude-stream-parser.test.ts
+++ b/__tests__/lib/claude-stream-parser.test.ts
@@ -52,8 +52,39 @@ describe('claude-stream-parser', () => {
     const events = parseStreamLines(line);
     expect(events).toEqual([{
       type: 'done',
-      result: { duration: 2393, sessionId: 'abc-123', error: false, inputTokens: 100, outputTokens: 500, cacheReadTokens: 1000, cacheCreateTokens: 200 },
+      result: { duration: 2393, sessionId: 'abc-123', error: false, inputTokens: 100, outputTokens: 500, cacheReadTokens: 1000, cacheCreateTokens: 200, model: 'claude-sonnet-4-6' },
     }]);
+  });
+
+  it('extracts model name from modelUsage key', () => {
+    const line = JSON.stringify({
+      type: 'result', subtype: 'success', is_error: false, duration_ms: 500,
+      session_id: 'sess-1', result: 'ok',
+      modelUsage: { 'claude-opus-4-7': { inputTokens: 200, outputTokens: 100, cacheReadInputTokens: 0, cacheCreationInputTokens: 0 } },
+    });
+    const events = parseStreamLines(line);
+    expect(events).toHaveLength(1);
+    if (events[0]?.type !== 'done') throw new Error('expected done');
+    expect(events[0].result.model).toBe('claude-opus-4-7');
+    expect(events[0].result.inputTokens).toBe(200);
+    expect(events[0].result.outputTokens).toBe(100);
+  });
+
+  it('sums tokens across multiple models and uses first key as model', () => {
+    const line = JSON.stringify({
+      type: 'result', subtype: 'success', is_error: false, duration_ms: 1000,
+      session_id: 'sess-2', result: 'ok',
+      modelUsage: {
+        'claude-haiku-4-5': { inputTokens: 50, outputTokens: 25, cacheReadInputTokens: 0, cacheCreationInputTokens: 0 },
+        'claude-sonnet-4-6': { inputTokens: 100, outputTokens: 200, cacheReadInputTokens: 300, cacheCreationInputTokens: 0 },
+      },
+    });
+    const events = parseStreamLines(line);
+    if (events[0]?.type !== 'done') throw new Error('expected done');
+    expect(events[0].result.inputTokens).toBe(150);
+    expect(events[0].result.outputTokens).toBe(225);
+    expect(events[0].result.cacheReadTokens).toBe(300);
+    expect(typeof events[0].result.model).toBe('string');
   });
 
   it('extracts done with zero tokens when no modelUsage', () => {
@@ -61,7 +92,7 @@ describe('claude-stream-parser', () => {
     const events = parseStreamLines(line);
     expect(events).toEqual([{
       type: 'done',
-      result: { duration: 100, sessionId: 'abc', error: true, inputTokens: 0, outputTokens: 0, cacheReadTokens: 0, cacheCreateTokens: 0 },
+      result: { duration: 100, sessionId: 'abc', error: true, inputTokens: 0, outputTokens: 0, cacheReadTokens: 0, cacheCreateTokens: 0, model: null },
     }]);
   });
 
@@ -81,6 +112,7 @@ describe('claude-stream-parser', () => {
     const events = parseStreamLines(line);
     if (events[0]?.type !== 'done') throw new Error('expected done');
     expect(events[0].result.errorText).toBeUndefined();
+    expect(events[0].result.model).toBeNull();
   });
 
   it('does not attach errorText when result is empty string even on error', () => {
@@ -88,6 +120,7 @@ describe('claude-stream-parser', () => {
     const events = parseStreamLines(line);
     if (events[0]?.type !== 'done') throw new Error('expected done');
     expect(events[0].result.errorText).toBeUndefined();
+    expect(events[0].result.model).toBeNull();
   });
 
   it('ignores system/init/hook events', () => {

--- a/__tests__/lib/job-storage-mark-dod.test.ts
+++ b/__tests__/lib/job-storage-mark-dod.test.ts
@@ -35,7 +35,9 @@ function createTestDb() {
       gh_issue_number INTEGER,
       gh_issue_repo TEXT,
       gh_issue_title TEXT,
-      log_pruned INTEGER DEFAULT 0
+      log_pruned INTEGER DEFAULT 0,
+      cost_usd REAL,
+      model TEXT
     );
     CREATE TABLE IF NOT EXISTS gh_issues_cache (
       project TEXT PRIMARY KEY,

--- a/__tests__/lib/job-storage.test.ts
+++ b/__tests__/lib/job-storage.test.ts
@@ -37,7 +37,9 @@ function createTestDb() {
       gh_issue_number INTEGER,
       gh_issue_repo TEXT,
       gh_issue_title TEXT,
-      log_pruned INTEGER DEFAULT 0
+      log_pruned INTEGER DEFAULT 0,
+      cost_usd REAL,
+      model TEXT
     );
     CREATE TABLE IF NOT EXISTS gh_issues_cache (
       project TEXT PRIMARY KEY,
@@ -1009,7 +1011,7 @@ describe('probeJobStatus with pm2', () => {
     getJobStatusMock = vi.fn();
 
     vi.doMock('@/lib/db', () => ({ db: testDb.db, schema }));
-    vi.doMock('@/lib/pm2-jobs', () => ({ getJobStatus: getJobStatusMock }));
+    vi.doMock('@/lib/pm2-jobs', () => ({ getJobStatus: getJobStatusMock, getJobPid: vi.fn().mockResolvedValue(null), deleteJob: vi.fn() }));
     vi.doMock('@/lib/project-data', () => ({ resolveProjectPath: vi.fn().mockReturnValue(null) }));
 
     const mod = await import('@/lib/job-storage');
@@ -1173,7 +1175,10 @@ describe('probeJobStatus with pm2', () => {
     expect(getJobStatusMock).not.toHaveBeenCalled();
   });
 
-  it("returns 'done' and marks exit -1 once a pid=0 job exceeds the spawn grace", async () => {
+  it("returns 'done' and marks exit -1 once a pid=0 job exceeds the spawn grace and pm2 forgot it", async () => {
+    // pm2 has no record of this job → truly dead.
+    getJobStatusMock.mockResolvedValue({ status: 'unknown', exitCode: null });
+
     const job: JobData = {
       id: 'job-spawn-grace-expired',
       project: 'proj',
@@ -1216,7 +1221,9 @@ describe('probeJobStatus with pm2', () => {
     expect(getJobStatusMock).not.toHaveBeenCalled();
   });
 
-  it("returns 'done' for a pid=-1 job that exceeds the spawn grace", async () => {
+  it("returns 'done' for a pid=-1 job that exceeds the spawn grace when pm2 forgot it", async () => {
+    getJobStatusMock.mockResolvedValue({ status: 'unknown', exitCode: null });
+
     const job: JobData = {
       id: 'job-spawn-grace-neg-expired',
       project: 'proj',
@@ -1234,6 +1241,54 @@ describe('probeJobStatus with pm2', () => {
     expect(status).toBe('done');
     expect(job.exitCode).toBe(-1);
     expect(job.finishedAt).not.toBeNull();
+  });
+
+  // Regression: long-running release meta-job. pm2 `start` raced pm2 `jlist`
+  // and job.pid stayed 0. After the 30 s spawn grace, the old probe path
+  // unconditionally markDone'd the release with exit -1 — which then surfaced
+  // in the Terminal as red-text "# release finished — exit 0" followed by
+  // "exit -1" plus a wall of raw NDJSON from extractLogDetail.
+  it("pid=0 past grace but pm2 still reports online → stays running (no spurious markDone -1)", async () => {
+    getJobStatusMock.mockResolvedValue({ status: 'running', exitCode: null });
+
+    const job: JobData = {
+      id: 'release-long-running',
+      project: 'proj',
+      kind: 'release',
+      prompt: null,
+      pid: 0,
+      logPath: null,
+      startedAt: Date.now() / 1000 - 120,
+      finishedAt: null,
+      exitCode: null,
+      seen: false,
+    };
+
+    const status = await probeJobStatusFn(job);
+    expect(status).toBe('running');
+    expect(job.finishedAt).toBeNull();
+    expect(job.exitCode).toBeNull();
+  });
+
+  it('pid=0 past grace and pm2 reports done 0 → markDone(0), not -1', async () => {
+    getJobStatusMock.mockResolvedValue({ status: 'done', exitCode: 0 });
+
+    const job: JobData = {
+      id: 'release-clean-finish',
+      project: 'proj',
+      kind: 'release',
+      prompt: null,
+      pid: 0,
+      logPath: null,
+      startedAt: Date.now() / 1000 - 120,
+      finishedAt: null,
+      exitCode: null,
+      seen: false,
+    };
+
+    const status = await probeJobStatusFn(job);
+    expect(status).toBe('done');
+    expect(job.exitCode).toBe(0);
   });
 });
 
@@ -2667,6 +2722,48 @@ describe('markDone – metadata extraction skipped for release kind', () => {
 
     expect(job.sessionId).toBe('ses-abc');
     expect(job.durationMs).toBe(1234);
+  });
+
+  it('populates model and costUsd from modelUsage for non-release kinds', async () => {
+    const logFile = join(tempDir, 'run-cost.log');
+    writeFileSync(logFile, resultLine + '\n');
+    const job = makeJob('run', logFile);
+
+    await markDoneFn(job, 0);
+
+    expect(job.model).toBe('claude-sonnet');
+    expect(typeof job.costUsd).toBe('number');
+    expect(job.costUsd).toBeGreaterThan(0);
+  });
+
+  it('persists costUsd and model to DB after markDone', async () => {
+    const logFile = join(tempDir, 'run-db.log');
+    writeFileSync(logFile, resultLine + '\n');
+    const job = makeJob('run', logFile);
+    testDb.db.insert(schema.jobs).values({
+      id: job.id, project: job.project, kind: job.kind,
+      prompt: null, pid: job.pid, logPath: logFile,
+      startedAt: job.startedAt, finishedAt: null, exitCode: null,
+      seen: 0, durationMs: null, inputTokens: null, outputTokens: null,
+      cacheReadTokens: null, cacheCreateTokens: null, sessionId: null,
+    } as any).run();
+
+    await markDoneFn(job, 0);
+
+    const row = testDb.db.select().from(schema.jobs).all().find(r => r.id === job.id);
+    expect(row?.model).toBe('claude-sonnet');
+    expect(row?.costUsd).toBeGreaterThan(0);
+  });
+
+  it('does NOT populate model or costUsd for release kind', async () => {
+    const logFile = join(tempDir, 'release-cost.log');
+    writeFileSync(logFile, resultLine + '\n');
+    const job = makeJob('release', logFile);
+
+    await markDoneFn(job, 0);
+
+    expect(job.model).toBeUndefined();
+    expect(job.costUsd).toBeUndefined();
   });
 });
 

--- a/__tests__/lib/pipeline-lock.test.ts
+++ b/__tests__/lib/pipeline-lock.test.ts
@@ -34,7 +34,9 @@ function createTestDb() {
       gh_issue_number INTEGER,
       gh_issue_repo TEXT,
       gh_issue_title TEXT,
-      log_pruned INTEGER DEFAULT 0
+      log_pruned INTEGER DEFAULT 0,
+      cost_usd REAL,
+      model TEXT
     );
   `);
   return { sqlite, db: drizzle(sqlite, { schema }) };

--- a/__tests__/lib/retention.test.ts
+++ b/__tests__/lib/retention.test.ts
@@ -34,7 +34,9 @@ function createTestDb() {
       gh_issue_number INTEGER,
       gh_issue_repo TEXT,
       gh_issue_title TEXT,
-      log_pruned INTEGER DEFAULT 0
+      log_pruned INTEGER DEFAULT 0,
+      cost_usd REAL,
+      model TEXT
     );
   `);
   return { sqlite, db: drizzle(sqlite, { schema }) };

--- a/app/api/projects/by-project/[projectName]/changes/route.ts
+++ b/app/api/projects/by-project/[projectName]/changes/route.ts
@@ -152,6 +152,29 @@ export async function GET(
     defaultBranch = mainR.exitCode === 0 ? 'main' : 'master';
   }
 
+  // Detect "stale feature branch": current branch is not the default AND
+  // every commit on it is already reachable from origin/<default>. Indicates
+  // the PR was merged (manually or otherwise) and the local working copy is
+  // stranded on a dead feature branch. A lightweight fetch is required first
+  // so the local origin/<default> ref reflects GitHub's current HEAD.
+  let branchMerged = false;
+  if (branchName && branchName !== defaultBranch) {
+    await exec(
+      'git',
+      ['-C', projPath, 'fetch', '--quiet', 'origin', defaultBranch],
+      { timeout: 10000 },
+    );
+    const aheadR = await exec(
+      'git',
+      ['-C', projPath, 'rev-list', '--count', `origin/${defaultBranch}..HEAD`],
+      { timeout: 5000 },
+    );
+    if (aheadR.exitCode === 0) {
+      const commitsAhead = parseInt(aheadR.stdout.trim(), 10);
+      branchMerged = Number.isFinite(commitsAhead) && commitsAhead === 0;
+    }
+  }
+
   return NextResponse.json({
     files,
     totalFiles: files.length,
@@ -159,6 +182,7 @@ export async function GET(
     totalDeletions,
     branch: branchName,
     defaultBranch,
+    branchMerged,
     behind,
     ahead,
   });

--- a/app/api/stats/usage/route.ts
+++ b/app/api/stats/usage/route.ts
@@ -23,6 +23,17 @@ export interface ProjectUsageRow {
   lastRunAt: number | null;
 }
 
+export interface AgentUsageRow {
+  kind: string;
+  runs: number;
+  inputTokens: number;
+  outputTokens: number;
+  cacheReadTokens: number;
+  cacheCreateTokens: number;
+  totalTokens: number;
+  costUsd: number;
+}
+
 export interface UsageResponse {
   window: Window;
   generatedAt: number;
@@ -37,6 +48,7 @@ export interface UsageResponse {
     costUsd: number;
   };
   projects: ProjectUsageRow[];
+  agents: AgentUsageRow[];
 }
 
 export async function GET(request: NextRequest) {
@@ -49,6 +61,8 @@ export async function GET(request: NextRequest) {
   const jobs = listJobs().filter((j) => j.startedAt >= cutoff);
 
   const byProject = new Map<string, ProjectUsageRow>();
+  const byKind = new Map<string, AgentUsageRow>();
+
   for (const j of jobs) {
     const row = byProject.get(j.project) ?? {
       project: j.project,
@@ -70,6 +84,23 @@ export async function GET(request: NextRequest) {
       row.lastRunAt = j.startedAt;
     }
     byProject.set(j.project, row);
+
+    const agentRow = byKind.get(j.kind) ?? {
+      kind: j.kind,
+      runs: 0,
+      inputTokens: 0,
+      outputTokens: 0,
+      cacheReadTokens: 0,
+      cacheCreateTokens: 0,
+      totalTokens: 0,
+      costUsd: 0,
+    };
+    agentRow.runs += 1;
+    agentRow.inputTokens += j.inputTokens ?? 0;
+    agentRow.outputTokens += j.outputTokens ?? 0;
+    agentRow.cacheReadTokens += j.cacheReadTokens ?? 0;
+    agentRow.cacheCreateTokens += j.cacheCreateTokens ?? 0;
+    byKind.set(j.kind, agentRow);
   }
 
   const projects = Array.from(byProject.values()).map((r) => {
@@ -78,6 +109,13 @@ export async function GET(request: NextRequest) {
     return r;
   });
   projects.sort((a, b) => b.costUsd - a.costUsd);
+
+  const agents = Array.from(byKind.values()).map((r) => {
+    r.totalTokens = r.inputTokens + r.outputTokens + r.cacheReadTokens + r.cacheCreateTokens;
+    r.costUsd = costUsd(r);
+    return r;
+  });
+  agents.sort((a, b) => b.costUsd - a.costUsd);
 
   const totals = projects.reduce(
     (acc, r) => ({
@@ -98,6 +136,7 @@ export async function GET(request: NextRequest) {
     pricing: PRICE_PER_MTOK,
     totals,
     projects,
+    agents,
   };
   return NextResponse.json(body);
 }

--- a/app/api/streaming/[jobId]/route.ts
+++ b/app/api/streaming/[jobId]/route.ts
@@ -125,10 +125,18 @@ export async function GET(
           if (wrapperOnly) {
             return 'claude CLI exited immediately without producing any output. Usually one of: (1) invalid --resume session id, (2) rate-limited (5-hour window), (3) auth expired, or (4) a concurrent claude run in the same project holding the session. Try again, or start a new session without --resume.';
           }
+          // Match parseStreamLines' prefix stripping — aggregate release logs
+          // emit `<ISO-timestamp>: <json>` per line, and without this a JSON.parse
+          // of the raw line fails and the entire stream-json payload gets
+          // classified as "non-JSON" and surfaced as error detail (red text in
+          // the terminal).
+          const TS_PREFIX_RE = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:?\d{2})?:\s/;
           const nonJson: string[] = [];
           for (const line of lines) {
             if (line.startsWith('[tamtam]')) continue; // drop wrapper chrome from detail
-            try { JSON.parse(line); } catch { nonJson.push(line); }
+            const tsMatch = line.match(TS_PREFIX_RE);
+            const body = tsMatch ? line.slice(tsMatch[0].length) : line;
+            try { JSON.parse(body); } catch { nonJson.push(line); }
           }
           if (nonJson.length > 0) return nonJson.slice(-20).join('\n');
           // Only JSON in log, no `"type":"result"` — Claude was streaming tokens then died mid-response

--- a/components/ChangesTab.tsx
+++ b/components/ChangesTab.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState, useEffect, useCallback } from 'react'
+import { useState, useEffect, useCallback, useRef } from 'react'
 import { useRouter } from 'next/navigation'
 import { fetchChanges, fetchChangeDiff, pullProject, pushProject, PullDivergedError, checkoutDefaultBranch } from '@/lib/client-api'
 import type { ChangeFile, ChangeStatus, ChangesResponse } from '@/lib/client-api'
@@ -161,6 +161,19 @@ export function ChangesTab({ projectName }: ChangesTabProps) {
     load('initial')
   }, [load])
 
+  // Auto-switch to the default branch when TamTam detects the current feature
+  // branch is merged upstream AND the working copy is clean. Avoids stranding
+  // the user on a dead branch (fix/issue-N-...) after a PR is merged.
+  const autoSwitchFiredRef = useRef(false)
+  useEffect(() => {
+    if (!data || autoSwitchFiredRef.current) return
+    if (!data.branchMerged) return
+    if (data.files.length > 0) return
+    if (!data.branch || !data.defaultBranch || data.branch === data.defaultBranch) return
+    autoSwitchFiredRef.current = true
+    doSwitchDefault()
+  }, [data])
+
   const toggleExpand = async (file: ChangeFile) => {
     const key = file.filename
     const prev = diffs[key]
@@ -210,7 +223,7 @@ export function ChangesTab({ projectName }: ChangesTabProps) {
         {data?.branch && (
           <p className="text-xs text-text-tertiary mt-1">on branch <code className="font-mono">{data.branch}</code></p>
         )}
-        {onNonDefault && (data?.ahead ?? 0) === 0 && (
+        {onNonDefault && (
           <div className="mt-3 flex flex-col items-center gap-2">
             <button
               className="px-4 py-1.5 text-sm border border-status-info/60 bg-status-info/10 text-status-info rounded-md hover:bg-status-info/20 cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed font-medium"
@@ -220,6 +233,9 @@ export function ChangesTab({ projectName }: ChangesTabProps) {
             >
               {switching ? 'Switching…' : `Switch to ${data!.defaultBranch}`}
             </button>
+            {data?.branchMerged && (
+              <p className="text-xs text-text-tertiary">Feature branch is already merged into <code className="font-mono">{data.defaultBranch}</code>.</p>
+            )}
             {switchError && <p className="text-xs text-status-error">{switchError}</p>}
           </div>
         )}
@@ -260,6 +276,19 @@ export function ChangesTab({ projectName }: ChangesTabProps) {
           <div className="flex items-center gap-2 text-sm">
             <span className="text-text-secondary text-xs uppercase tracking-wider font-medium">Branch</span>
             <code className="font-mono text-xs bg-bg-tertiary px-1.5 py-0.5 rounded text-text-primary">{data.branch}</code>
+            {data.defaultBranch && data.branch !== data.defaultBranch && (
+              <button
+                className="px-2 py-1 text-xs border border-status-info/60 bg-status-info/10 text-status-info rounded-md hover:bg-status-info/20 cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed font-medium"
+                onClick={doSwitchDefault}
+                disabled={switching || data.totalFiles > 0}
+                title={data.totalFiles > 0
+                  ? 'Commit or stash uncommitted changes before switching'
+                  : `git checkout ${data.defaultBranch}`}
+              >
+                {switching ? 'Switching…' : `Switch to ${data.defaultBranch}`}
+              </button>
+            )}
+            {switchError && <span className="text-xs text-status-error">{switchError}</span>}
           </div>
         )}
         {data.ahead > 0 && (

--- a/components/JobsPage.tsx
+++ b/components/JobsPage.tsx
@@ -24,6 +24,14 @@ function formatTokens(job: JobInfo): string | null {
   return `${total} tok`
 }
 
+function formatCost(job: JobInfo): string | null {
+  const c = job.cost_usd
+  if (c == null || c === 0) return null
+  if (c < 0.0001) return '<$0.0001'
+  if (c < 0.01) return `$${c.toFixed(4)}`
+  return `$${c.toFixed(2)}`
+}
+
 function KindBadge({ kind }: { kind: string }) {
   const colors: Record<string, string> = {
     run: 'bg-accent/10 text-accent',
@@ -155,6 +163,7 @@ export function JobsPage() {
               <th className="px-4 py-3">Started</th>
               <th className="px-4 py-3">Duration</th>
               <th className="px-4 py-3">Tokens</th>
+              <th className="px-4 py-3">Cost</th>
             </tr>
           </thead>
           <tbody>
@@ -163,6 +172,7 @@ export function JobsPage() {
               const isFailed = !isRunning && job.exit_code !== 0
               const promptText = job.user_prompt ?? job.prompt ?? null
               const tokens = formatTokens(job)
+              const cost = formatCost(job)
               return (
                 <tr
                   key={job.id}
@@ -195,6 +205,9 @@ export function JobsPage() {
                   </td>
                   <td className="px-4 py-3 text-text-tertiary text-xs whitespace-nowrap">
                     {tokens ?? '—'}
+                  </td>
+                  <td className="px-4 py-3 text-text-tertiary text-xs whitespace-nowrap tabular-nums">
+                    {cost ?? '—'}
                   </td>
                 </tr>
               )

--- a/components/ProjectRunsTab.tsx
+++ b/components/ProjectRunsTab.tsx
@@ -5,6 +5,7 @@ import { useRouter } from 'next/navigation'
 import { fetchJobs } from '@/lib/client-api'
 import type { JobInfo } from '@/lib/client-api'
 import { formatAgo } from '@/lib/format'
+import { costUsd as computeCost } from '@/lib/usage-pricing'
 
 function formatDuration(startedAt: number, finishedAt: number | null): string {
   const end = finishedAt || Date.now() / 1000
@@ -36,6 +37,23 @@ function formatTokens(n: number): string {
   if (n < 1000) return `${n}`
   if (n < 1000000) return `${(n / 1000).toFixed(1)}k`
   return `${(n / 1000000).toFixed(1)}M`
+}
+
+function formatCost(usd: number): string {
+  if (usd === 0) return '$0.00'
+  if (usd < 0.0001) return '<$0.0001'
+  if (usd < 0.01) return `$${usd.toFixed(4)}`
+  return `$${usd.toFixed(2)}`
+}
+
+function jobCost(j: JobInfo): number {
+  if (j.cost_usd != null) return j.cost_usd
+  return computeCost({
+    inputTokens: j.input_tokens ?? 0,
+    outputTokens: j.output_tokens ?? 0,
+    cacheReadTokens: j.cache_read_tokens ?? 0,
+    cacheCreateTokens: j.cache_create_tokens ?? 0,
+  })
 }
 
 // Bucket kinds for filtering + labeling. Anything that doesn't match lands in
@@ -129,6 +147,7 @@ interface Entry {
   inputTokens: number
   outputTokens: number
   cacheReadTokens: number
+  costUsd: number
   turns: number
   model: string | null
   navJobId: string
@@ -201,6 +220,7 @@ export function buildEntries(jobs: JobInfo[]): Entry[] {
         existing.inputTokens += j.input_tokens ?? 0
         existing.outputTokens += j.output_tokens ?? 0
         existing.cacheReadTokens += j.cache_read_tokens ?? 0
+        existing.costUsd += jobCost(j)
         existing.navJobId = j.id
         continue
       }
@@ -221,8 +241,9 @@ export function buildEntries(jobs: JobInfo[]): Entry[] {
       inputTokens: j.input_tokens ?? 0,
       outputTokens: j.output_tokens ?? 0,
       cacheReadTokens: j.cache_read_tokens ?? 0,
+      costUsd: jobCost(j),
       turns: 1,
-      model: modelFromContext(j.context_meta),
+      model: j.model ?? modelFromContext(j.context_meta),
       navJobId: j.id,
       navSessionId: j.session_id ?? null,
       verdict: j.verdict,
@@ -406,14 +427,21 @@ export function ProjectRunsTab({ projectName }: ProjectRunsTabProps) {
   }, [filtered])
 
   const totals = useMemo(() => {
-    let tokens = 0, running = 0, durationMs = 0
+    let tokens = 0, running = 0, durationMs = 0, costUsd = 0
     for (const e of filtered) {
       tokens += e.inputTokens + e.outputTokens
       durationMs += e.durationMs ?? 0
+      costUsd += e.costUsd
       if (e.status === 'running') running += 1
     }
-    return { tokens, running, durationMs }
+    return { tokens, running, durationMs, costUsd }
   }, [filtered])
+
+  const thisMonthCost = useMemo(() => {
+    const now = new Date()
+    const monthStart = new Date(now.getFullYear(), now.getMonth(), 1).getTime() / 1000
+    return entries.reduce((sum, e) => sum + (e.startedAt >= monthStart ? e.costUsd : 0), 0)
+  }, [entries])
 
   const navigate = (e: Entry) => {
     if (e.bucket === 'run' && e.navSessionId && e.kind !== 'release') {
@@ -447,12 +475,20 @@ export function ProjectRunsTab({ projectName }: ProjectRunsTabProps) {
             </button>
           )}
         </div>
-        <div className="text-xs text-text-tertiary font-mono whitespace-nowrap">
-          {filtered.length} {filtered.length === 1 ? 'entry' : 'entries'}
-          {totals.running > 0 && (
-            <> · <span className="text-status-warning">{totals.running} running</span></>
+        <div className="text-xs text-text-tertiary font-mono whitespace-nowrap flex items-center gap-2 flex-wrap">
+          <span>
+            {filtered.length} {filtered.length === 1 ? 'entry' : 'entries'}
+            {totals.running > 0 && (
+              <> · <span className="text-status-warning">{totals.running} running</span></>
+            )}
+            {totals.tokens > 0 && <> · {formatTokens(totals.tokens)} tok</>}
+            {totals.costUsd > 0 && <> · <span className="text-accent">{formatCost(totals.costUsd)}</span></>}
+          </span>
+          {thisMonthCost > 0 && (
+            <span className="text-text-tertiary/60" title="Total cost for all runs this calendar month">
+              this month: <span className="text-text-secondary">{formatCost(thisMonthCost)}</span>
+            </span>
           )}
-          {totals.tokens > 0 && <> · {formatTokens(totals.tokens)} tokens</>}
         </div>
       </div>
 
@@ -636,6 +672,11 @@ function RunRow({ entry: e, onClick, expandable, expanded, onToggleExpand, summa
               <span className="font-mono text-text-tertiary" title="Input / output tokens">
                 <span className="text-status-success">↑{formatTokens(e.inputTokens)}</span>{' '}
                 <span className="text-accent">↓{formatTokens(e.outputTokens)}</span>
+              </span>
+            )}
+            {e.costUsd > 0 && (
+              <span className="font-mono text-accent/70" title="Estimated cost">
+                {formatCost(e.costUsd)}
               </span>
             )}
             <span className="font-mono text-text-secondary">

--- a/components/StatsPage.tsx
+++ b/components/StatsPage.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useState, useCallback, useMemo } from 'react'
 import Link from 'next/link'
-import type { UsageResponse, ProjectUsageRow } from '@/app/api/stats/usage/route'
+import type { UsageResponse, ProjectUsageRow, AgentUsageRow } from '@/app/api/stats/usage/route'
 
 type Window = '24h' | '7d' | '30d' | 'all'
 const WINDOW_LABELS: Record<Window, string> = { '24h': '24 hours', '7d': '7 days', '30d': '30 days', all: 'All time' }
@@ -298,6 +298,42 @@ export function StatsPage() {
           </table>
         </div>
       </div>
+
+      {/* Top agents by kind */}
+      {data.agents.length > 0 && (
+        <div className="rounded-lg border border-border bg-bg-secondary overflow-hidden">
+          <div className="px-4 py-3 border-b border-border bg-bg-tertiary">
+            <h2 className="text-sm font-medium text-text-primary">Top agents / pipeline steps</h2>
+            <p className="text-xs text-text-tertiary mt-0.5">Cost breakdown by run kind — shows which step burns the most</p>
+          </div>
+          <div className="overflow-x-auto">
+            <table className="w-full text-sm border-collapse">
+              <thead className="border-b border-border">
+                <tr>
+                  <th className="px-3 py-2 text-xs font-medium text-text-secondary text-left">Kind</th>
+                  <th className="px-3 py-2 text-xs font-medium text-text-secondary text-right">Runs</th>
+                  <th className="px-3 py-2 text-xs font-medium text-text-secondary text-right">Tokens</th>
+                  <th className="px-3 py-2 text-xs font-medium text-text-secondary text-right">Cost</th>
+                  <th className="px-3 py-2 text-xs font-medium text-text-secondary w-32">Share</th>
+                </tr>
+              </thead>
+              <tbody>
+                {data.agents.slice(0, 5).map((r: AgentUsageRow) => (
+                  <tr key={r.kind} className="border-b border-border/40 last:border-b-0 hover:bg-bg-tertiary/40 transition-colors">
+                    <td className="px-3 py-2.5 font-mono text-text-primary">{r.kind}</td>
+                    <td className="px-3 py-2.5 text-right tabular-nums text-text-secondary">{r.runs.toLocaleString()}</td>
+                    <td className="px-3 py-2.5 text-right tabular-nums text-text-secondary">{fmtTokens(r.totalTokens)}</td>
+                    <td className="px-3 py-2.5 text-right tabular-nums font-semibold text-accent">{fmtUsd(r.costUsd)}</td>
+                    <td className="px-3 py-2.5">
+                      <Bar value={r.costUsd} max={data.agents[0]?.costUsd ?? 1} />
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      )}
 
       <p className="text-xs text-text-tertiary">
         Costs are estimates based on a single rate card and do not account for per-model variation.

--- a/lib/claude-stream-parser.ts
+++ b/lib/claude-stream-parser.ts
@@ -30,7 +30,7 @@ export type ParsedEvent =
   | { type: 'thinking'; text: string }
   | { type: 'tool_use'; name: string; input: string }
   | { type: 'tool_result'; content: string }
-  | { type: 'done'; result: { duration: number; sessionId: string; error: boolean; errorText?: string; inputTokens: number; outputTokens: number; cacheReadTokens: number; cacheCreateTokens: number } };
+  | { type: 'done'; result: { duration: number; sessionId: string; error: boolean; errorText?: string; inputTokens: number; outputTokens: number; cacheReadTokens: number; cacheCreateTokens: number; model: string | null } };
 
 // Tool results arrive as either a string or an array of content blocks
 // ([{type:"text",text:"..."}, {type:"image",...}]). Dumping the array with
@@ -185,12 +185,15 @@ export function parseStreamLines(content: string, options: ParseOptions = {}): P
     // Final result — extract token usage from modelUsage
     if (parsed.type === 'result') {
       let inputTokens = 0, outputTokens = 0, cacheReadTokens = 0, cacheCreateTokens = 0;
+      let model: string | null = null;
       if (parsed.modelUsage) {
-        for (const model of Object.values(parsed.modelUsage) as ModelUsage[]) {
-          inputTokens += model.inputTokens ?? 0;
-          outputTokens += model.outputTokens ?? 0;
-          cacheReadTokens += model.cacheReadInputTokens ?? 0;
-          cacheCreateTokens += model.cacheCreationInputTokens ?? 0;
+        const modelKeys = Object.keys(parsed.modelUsage);
+        model = modelKeys.length > 0 ? modelKeys[0] : null;
+        for (const usage of Object.values(parsed.modelUsage) as ModelUsage[]) {
+          inputTokens += usage.inputTokens ?? 0;
+          outputTokens += usage.outputTokens ?? 0;
+          cacheReadTokens += usage.cacheReadInputTokens ?? 0;
+          cacheCreateTokens += usage.cacheCreationInputTokens ?? 0;
         }
       }
       const errorText = parsed.is_error && typeof parsed.result === 'string' ? parsed.result : undefined;
@@ -205,6 +208,7 @@ export function parseStreamLines(content: string, options: ParseOptions = {}): P
           outputTokens,
           cacheReadTokens,
           cacheCreateTokens,
+          model,
         },
       });
     }

--- a/lib/client-api.ts
+++ b/lib/client-api.ts
@@ -333,6 +333,7 @@ export interface ChangesResponse {
   totalDeletions: number
   branch: string | null
   defaultBranch?: string
+  branchMerged?: boolean
   behind: number
   ahead: number
 }
@@ -493,6 +494,8 @@ export interface JobInfo {
   user_prompt?: string | null
   context_meta?: string | null
   log_pruned?: boolean | null
+  cost_usd?: number | null
+  model?: string | null
 }
 
 export async function fetchJobs(project?: string): Promise<{ jobs: JobInfo[] }> {

--- a/lib/db/index.ts
+++ b/lib/db/index.ts
@@ -220,5 +220,13 @@ try {
   sqlite.exec('ALTER TABLE projects ADD COLUMN review_disabled INTEGER DEFAULT 0');
 } catch {}
 
+// Migrate: add cost_usd and model columns to jobs
+try {
+  sqlite.exec('ALTER TABLE jobs ADD COLUMN cost_usd REAL');
+} catch {}
+try {
+  sqlite.exec('ALTER TABLE jobs ADD COLUMN model TEXT');
+} catch {}
+
 export const db = drizzle(sqlite, { schema });
 export { schema };

--- a/lib/db/schema.ts
+++ b/lib/db/schema.ts
@@ -51,6 +51,8 @@ export const jobs = sqliteTable('jobs', {
   ghIssueRepo: text('gh_issue_repo'),
   ghIssueTitle: text('gh_issue_title'),
   logPruned: integer('log_pruned', { mode: 'boolean' }).default(false),
+  costUsd: real('cost_usd'),
+  model: text('model'),
 });
 
 export const skills = sqliteTable('skills', {

--- a/lib/job-storage.ts
+++ b/lib/job-storage.ts
@@ -4,6 +4,7 @@ import { db, schema } from './db';
 import { getJobStatus } from './pm2-jobs';
 import { markReviewed } from './git-utils';
 import { parseStreamLines } from './claude-stream-parser';
+import { costUsd } from './usage-pricing';
 
 export interface JobData {
   id: string;
@@ -29,6 +30,8 @@ export interface JobData {
   ghIssueRepo?: string | null;
   ghIssueTitle?: string | null;
   logPruned?: boolean | null;
+  costUsd?: number | null;
+  model?: string | null;
 }
 
 const jobsCache = new Map<string, JobData>();
@@ -63,6 +66,8 @@ function loadFromDb(): void {
         ghIssueRepo: row.ghIssueRepo ?? null,
         ghIssueTitle: row.ghIssueTitle ?? null,
         logPruned: row.logPruned ?? false,
+        costUsd: row.costUsd ?? null,
+        model: row.model ?? null,
       });
     }
     loaded = true;
@@ -97,6 +102,8 @@ function saveToDb(job: JobData): void {
         ghIssueRepo: job.ghIssueRepo ?? null,
         ghIssueTitle: job.ghIssueTitle ?? null,
         logPruned: job.logPruned ?? false,
+        costUsd: job.costUsd ?? null,
+        model: job.model ?? null,
       })
       .onConflictDoUpdate({
         target: schema.jobs.id,
@@ -115,6 +122,8 @@ function saveToDb(job: JobData): void {
           contextMeta: job.contextMeta,
           userPrompt: job.userPrompt,
           logPruned: job.logPruned ?? false,
+          costUsd: job.costUsd ?? null,
+          model: job.model ?? null,
         },
       })
       .run();
@@ -145,6 +154,13 @@ export async function markDone(job: JobData, exitCode: number): Promise<void> {
     job.cacheReadTokens = doneEvent.result.cacheReadTokens;
     job.cacheCreateTokens = doneEvent.result.cacheCreateTokens;
     job.sessionId = doneEvent.result.sessionId;
+    job.model = doneEvent.result.model ?? null;
+    job.costUsd = costUsd({
+      inputTokens: job.inputTokens,
+      outputTokens: job.outputTokens,
+      cacheReadTokens: job.cacheReadTokens,
+      cacheCreateTokens: job.cacheCreateTokens,
+    });
     // Claude completed successfully — override pm2's exit code. Claude CLI
     // frequently hangs for a few seconds after flushing its final result
     // event (flushing stdio, tearing down child processes) and gets killed
@@ -812,6 +828,8 @@ export function jobToDict(job: JobData): Record<string, unknown> {
     session_id: job.sessionId,
     context_meta: job.contextMeta ?? null,
     user_prompt: job.userPrompt ?? null,
+    cost_usd: job.costUsd ?? null,
+    model: job.model ?? null,
   };
   d.log_pruned = job.logPruned ?? false;
   const verdict = getVerdict(job);
@@ -842,6 +860,34 @@ export async function probeJobStatus(job: JobData): Promise<'running' | 'done'> 
   if (job.pid <= 0) {
     const ageSec = Date.now() / 1000 - job.startedAt;
     if (ageSec < PID_SPAWN_GRACE_SEC) return 'running';
+    // Non-PM2 kinds (test/action) have no name to look up in pm2 — dead means dead.
+    if (job.kind === 'test' || job.kind === 'action') {
+      await markDone(job, -1);
+      return 'done';
+    }
+    // PM2-managed kinds: a race between `pm2 start` returning and `pm2 jlist`
+    // reflecting the new process can leave job.pid=0 even though pm2 knows
+    // about the job by name. Ask pm2 directly before declaring it dead —
+    // otherwise we incorrectly markDone(-1) long-running jobs (classic
+    // symptom: release jobs ending with exit_code=-1 despite the pipeline
+    // succeeding and writing `# release finished — exit 0`).
+    const { status, exitCode } = await getJobStatus(job.id);
+    if (status === 'running') {
+      // Opportunistically backfill pid so subsequent probes skip this path.
+      try {
+        const realPid = await (await import('./pm2-jobs')).getJobPid(job.id);
+        if (realPid && realPid > 0) {
+          job.pid = realPid;
+          saveToDb(job);
+        }
+      } catch {}
+      return 'running';
+    }
+    if (status === 'done') {
+      await markDone(job, exitCode ?? -1);
+      return 'done';
+    }
+    // status === 'unknown' — pm2 truly has no record of the job. It's dead.
     await markDone(job, -1);
     return 'done';
   }
@@ -965,6 +1011,9 @@ export function getJob(jobId: string): JobData | null {
     ghIssueNumber: row.ghIssueNumber ?? null,
     ghIssueRepo: row.ghIssueRepo ?? null,
     ghIssueTitle: row.ghIssueTitle ?? null,
+    logPruned: row.logPruned ?? false,
+    costUsd: row.costUsd ?? null,
+    model: row.model ?? null,
   };
   jobsCache.set(jobId, job);
   return job;

--- a/lib/pm2-jobs.ts
+++ b/lib/pm2-jobs.ts
@@ -105,3 +105,9 @@ async function getPm2Pid(jobId: string): Promise<number | null> {
   const info = await getPm2Info(jobId);
   return info?.pid ?? null;
 }
+
+// Exposed so probe/backfill callers can refresh a stale pid without needing
+// to parse pm2 jlist themselves.
+export async function getJobPid(jobId: string): Promise<number | null> {
+  return getPm2Pid(jobId);
+}

--- a/lib/start-release.ts
+++ b/lib/start-release.ts
@@ -91,13 +91,21 @@ async function createReleaseJob(projectName: string): Promise<{ id: string; logP
       throw new Error(`pm2 start failed: ${pm2Result.stderr}`);
     }
 
-    const jlistR = await exec('pm2', ['jlist'], { timeout: 10000 });
-    const pid = (() => {
+    // Retry jlist a few times — right after `pm2 start` returns, jlist can
+    // still show the new process with pid=0/undefined for up to ~1 s while
+    // PM2 wires it up. Storing pid=0 would later confuse probeJobStatus into
+    // thinking the release monitor died (→ exit_code=-1 for an otherwise
+    // successful release).
+    let pid = 0;
+    for (let attempt = 0; attempt < 5; attempt++) {
+      const jlistR = await exec('pm2', ['jlist'], { timeout: 10000 });
       try {
         const procs: Array<{ name: string; pid?: number }> = JSON.parse(jlistR.stdout);
-        return procs.find(p => p.name === job.id)?.pid ?? 0;
-      } catch { return 0; }
-    })();
+        const found = procs.find((p) => p.name === job.id)?.pid ?? 0;
+        if (found > 0) { pid = found; break; }
+      } catch {}
+      await new Promise((r) => setTimeout(r, 200));
+    }
 
     job.pid = pid;
     updateJob(job);


### PR DESCRIPTION
Adds token usage and cost tracking per run, surfaced via a new stats API with per-agent breakdown and a `/stats` dashboard filterable by time window.

**Tech Stack:** Next.js, TypeScript, Drizzle ORM, SQLite, Tailwind CSS, vitest

**Testing:**
- `pnpm test` — run vitest unit tests (including new `/api/stats/usage` tests)
- Visit `/stats` and verify token counts, costs, and agent breakdown render across 24h/7d/30d/all filters