### PR TITLE
fix: Add unified release trace view so debugging a failed pipeline doesn't require hopping between job pages

### DIFF
--- a/__tests__/api/release-trace.test.ts
+++ b/__tests__/api/release-trace.test.ts
@@ -1,0 +1,215 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { NextRequest } from 'next/server';
+import type { JobData } from '@/lib/job-storage';
+
+function makeJob(overrides: Partial<JobData> = {}): JobData {
+  return {
+    id: 'job-1',
+    project: 'proj1',
+    kind: 'run',
+    prompt: null,
+    pid: 1234,
+    logPath: null,
+    startedAt: 1000,
+    finishedAt: null,
+    exitCode: null,
+    seen: false,
+    ...overrides,
+  };
+}
+
+describe('GET /api/projects/by-project/{name}/release/{releaseId}', () => {
+  let GET: (req: NextRequest, ctx: { params: Promise<{ projectName: string; releaseId: string }> }) => Promise<Response>;
+  let listJobsMock: ReturnType<typeof vi.fn>;
+  let getVerdictMock: ReturnType<typeof vi.fn>;
+  let readLogMock: ReturnType<typeof vi.fn>;
+  let resolveProjectPathMock: ReturnType<typeof vi.fn>;
+  let execMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(async () => {
+    vi.resetModules();
+    listJobsMock = vi.fn().mockReturnValue([]);
+    getVerdictMock = vi.fn().mockReturnValue(null);
+    readLogMock = vi.fn().mockReturnValue('');
+    resolveProjectPathMock = vi.fn().mockReturnValue('/workspace/proj1');
+    execMock = vi.fn().mockResolvedValue({ exitCode: 0, stdout: 'main', stderr: '' });
+
+    vi.doMock('@/lib/job-storage', () => ({
+      listJobs: listJobsMock,
+      getVerdict: getVerdictMock,
+      readLog: readLogMock,
+    }));
+    vi.doMock('@/lib/project-data', () => ({
+      resolveProjectPath: resolveProjectPathMock,
+    }));
+    vi.doMock('@/lib/shell', () => ({ exec: execMock }));
+
+    const mod = await import(
+      '@/app/api/projects/by-project/[projectName]/release/[releaseId]/route'
+    );
+    GET = mod.GET as typeof GET;
+  });
+
+  afterEach(() => vi.resetModules());
+
+  function req(name = 'proj1') {
+    return new NextRequest(`http://localhost/api/projects/by-project/${name}/release/rel-1`);
+  }
+
+  function params(name = 'proj1', releaseId = 'rel-1') {
+    return { params: Promise.resolve({ projectName: name, releaseId }) };
+  }
+
+  it('returns 404 when no release job found', async () => {
+    listJobsMock.mockReturnValue([]);
+    const res = await GET(req(), params());
+    expect(res.status).toBe(404);
+    const data = await res.json();
+    expect(data.error).toContain('not found');
+  });
+
+  it('returns 404 when job exists but kind is not release', async () => {
+    listJobsMock.mockReturnValue([
+      makeJob({ id: 'rel-1', project: 'proj1', kind: 'review', releaseId: 'rel-1' }),
+    ]);
+    const res = await GET(req(), params());
+    expect(res.status).toBe(404);
+  });
+
+  it('returns 404 when release belongs to different project', async () => {
+    listJobsMock.mockReturnValue([
+      makeJob({ id: 'rel-1', project: 'other-proj', kind: 'release', releaseId: 'rel-1' }),
+    ]);
+    const res = await GET(req('proj1'), params('proj1'));
+    expect(res.status).toBe(404);
+  });
+
+  it('returns release with no steps when no child jobs share releaseId', async () => {
+    listJobsMock.mockReturnValue([
+      makeJob({ id: 'rel-1', project: 'proj1', kind: 'release', startedAt: 1000, finishedAt: 1060, exitCode: 0 }),
+    ]);
+    const res = await GET(req(), params());
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.release_id).toBe('rel-1');
+    expect(data.project).toBe('proj1');
+    expect(data.branch).toBe('main');
+    expect(data.started_at).toBe(1000);
+    expect(data.finished_at).toBe(1060);
+    expect(data.exit_code).toBe(0);
+    expect(data.steps).toEqual([]);
+  });
+
+  it('aggregates pipeline step jobs that share the releaseId', async () => {
+    const testJob = makeJob({ id: 'test-1', project: 'proj1', kind: 'test', startedAt: 1001, finishedAt: 1020, exitCode: 0, releaseId: 'rel-1' });
+    const reviewJob = makeJob({ id: 'review-1', project: 'proj1', kind: 'review', startedAt: 1021, finishedAt: 1050, exitCode: 0, releaseId: 'rel-1' });
+    const releaseJob = makeJob({ id: 'rel-1', project: 'proj1', kind: 'release', startedAt: 1000, finishedAt: 1060, exitCode: 0 });
+
+    listJobsMock.mockReturnValue([releaseJob, testJob, reviewJob]);
+    getVerdictMock.mockImplementation((j: JobData) => j.id === 'review-1' ? 'LGTM' : null);
+    readLogMock.mockReturnValue('test output');
+
+    const res = await GET(req(), params());
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.steps).toHaveLength(2);
+    expect(data.steps[0].job_id).toBe('test-1');
+    expect(data.steps[0].kind).toBe('test');
+    expect(data.steps[0].status).toBe('done');
+    expect(data.steps[0].exit_code).toBe(0);
+    expect(data.steps[1].job_id).toBe('review-1');
+    expect(data.steps[1].kind).toBe('review');
+    expect(data.steps[1].verdict).toBe('LGTM');
+  });
+
+  it('excludes jobs from other projects or with different releaseId', async () => {
+    const releaseJob = makeJob({ id: 'rel-1', project: 'proj1', kind: 'release', startedAt: 1000 });
+    const ownStep = makeJob({ id: 'test-1', project: 'proj1', kind: 'test', startedAt: 1001, releaseId: 'rel-1' });
+    const otherProj = makeJob({ id: 'test-2', project: 'other', kind: 'test', startedAt: 1001, releaseId: 'rel-1' });
+    const differentRelease = makeJob({ id: 'test-3', project: 'proj1', kind: 'test', startedAt: 1001, releaseId: 'rel-999' });
+
+    listJobsMock.mockReturnValue([releaseJob, ownStep, otherProj, differentRelease]);
+
+    const res = await GET(req(), params());
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.steps).toHaveLength(1);
+    expect(data.steps[0].job_id).toBe('test-1');
+  });
+
+  it('returns running steps with status running when finishedAt is null', async () => {
+    const releaseJob = makeJob({ id: 'rel-1', project: 'proj1', kind: 'release', startedAt: 1000 });
+    const runningStep = makeJob({ id: 'review-1', project: 'proj1', kind: 'review', startedAt: 1001, finishedAt: null, exitCode: null, releaseId: 'rel-1' });
+
+    listJobsMock.mockReturnValue([releaseJob, runningStep]);
+
+    const res = await GET(req(), params());
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.steps[0].status).toBe('running');
+    expect(data.finished_at).toBeNull();
+  });
+
+  it('orders steps by startedAt ascending', async () => {
+    const releaseJob = makeJob({ id: 'rel-1', project: 'proj1', kind: 'release', startedAt: 1000 });
+    const commit = makeJob({ id: 'commit-1', project: 'proj1', kind: 'commit', startedAt: 1050, finishedAt: 1055, exitCode: 0, releaseId: 'rel-1' });
+    const test = makeJob({ id: 'test-1', project: 'proj1', kind: 'test', startedAt: 1001, finishedAt: 1020, exitCode: 0, releaseId: 'rel-1' });
+    const review = makeJob({ id: 'review-1', project: 'proj1', kind: 'review', startedAt: 1021, finishedAt: 1049, exitCode: 0, releaseId: 'rel-1' });
+
+    listJobsMock.mockReturnValue([commit, test, review, releaseJob]);
+
+    const res = await GET(req(), params());
+    const data = await res.json();
+    expect(data.steps.map((s: { kind: string }) => s.kind)).toEqual(['test', 'review', 'commit']);
+  });
+
+  it('handles git branch resolution failure gracefully', async () => {
+    execMock.mockResolvedValue({ exitCode: 1, stdout: '', stderr: 'not a git repo' });
+    listJobsMock.mockReturnValue([
+      makeJob({ id: 'rel-1', project: 'proj1', kind: 'release', startedAt: 1000 }),
+    ]);
+
+    const res = await GET(req(), params());
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.branch).toBeNull();
+  });
+
+  it('handles missing project path gracefully', async () => {
+    resolveProjectPathMock.mockReturnValue(null);
+    listJobsMock.mockReturnValue([
+      makeJob({ id: 'rel-1', project: 'proj1', kind: 'release', startedAt: 1000 }),
+    ]);
+
+    const res = await GET(req(), params());
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.branch).toBeNull();
+  });
+
+  it('includes log excerpt in step data', async () => {
+    readLogMock.mockReturnValue('this is the log output from the test run');
+    const releaseJob = makeJob({ id: 'rel-1', project: 'proj1', kind: 'release', startedAt: 1000 });
+    const testStep = makeJob({ id: 'test-1', project: 'proj1', kind: 'test', startedAt: 1001, finishedAt: 1010, exitCode: 0, releaseId: 'rel-1' });
+
+    listJobsMock.mockReturnValue([releaseJob, testStep]);
+
+    const res = await GET(req(), params());
+    const data = await res.json();
+    expect(data.steps[0].log_excerpt).toBeTruthy();
+  });
+
+  it('includes fix-push step kind in aggregation', async () => {
+    const releaseJob = makeJob({ id: 'rel-1', project: 'proj1', kind: 'release', startedAt: 1000 });
+    const pushStep = makeJob({ id: 'push-1', project: 'proj1', kind: 'push', startedAt: 1030, finishedAt: 1031, exitCode: 1, releaseId: 'rel-1' });
+    const fixPushStep = makeJob({ id: 'fp-1', project: 'proj1', kind: 'fix-push', startedAt: 1032, finishedAt: 1045, exitCode: 0, releaseId: 'rel-1' });
+
+    listJobsMock.mockReturnValue([releaseJob, pushStep, fixPushStep]);
+
+    const res = await GET(req(), params());
+    const data = await res.json();
+    const kinds = data.steps.map((s: { kind: string }) => s.kind);
+    expect(kinds).toContain('push');
+    expect(kinds).toContain('fix-push');
+  });
+});

--- a/__tests__/lib/job-storage-mark-dod.test.ts
+++ b/__tests__/lib/job-storage-mark-dod.test.ts
@@ -37,7 +37,8 @@ function createTestDb() {
       gh_issue_title TEXT,
       log_pruned INTEGER DEFAULT 0,
       cost_usd REAL,
-      model TEXT
+      model TEXT,
+      release_id TEXT
     );
     CREATE TABLE IF NOT EXISTS gh_issues_cache (
       project TEXT PRIMARY KEY,

--- a/__tests__/lib/job-storage.test.ts
+++ b/__tests__/lib/job-storage.test.ts
@@ -39,7 +39,8 @@ function createTestDb() {
       gh_issue_title TEXT,
       log_pruned INTEGER DEFAULT 0,
       cost_usd REAL,
-      model TEXT
+      model TEXT,
+      release_id TEXT
     );
     CREATE TABLE IF NOT EXISTS gh_issues_cache (
       project TEXT PRIMARY KEY,

--- a/__tests__/lib/pipeline-lock.test.ts
+++ b/__tests__/lib/pipeline-lock.test.ts
@@ -36,7 +36,8 @@ function createTestDb() {
       gh_issue_title TEXT,
       log_pruned INTEGER DEFAULT 0,
       cost_usd REAL,
-      model TEXT
+      model TEXT,
+      release_id TEXT
     );
   `);
   return { sqlite, db: drizzle(sqlite, { schema }) };

--- a/__tests__/lib/retention.test.ts
+++ b/__tests__/lib/retention.test.ts
@@ -36,7 +36,8 @@ function createTestDb() {
       gh_issue_title TEXT,
       log_pruned INTEGER DEFAULT 0,
       cost_usd REAL,
-      model TEXT
+      model TEXT,
+      release_id TEXT
     );
   `);
   return { sqlite, db: drizzle(sqlite, { schema }) };

--- a/app/api/projects/by-project/[projectName]/release/[releaseId]/route.ts
+++ b/app/api/projects/by-project/[projectName]/release/[releaseId]/route.ts
@@ -1,0 +1,77 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { listJobs, getVerdict, readLog } from '@/lib/job-storage';
+import { exec } from '@/lib/shell';
+import { resolveProjectPath } from '@/lib/project-data';
+
+const PIPELINE_STEP_KINDS = ['test', 'review', 'fix', 'commit', 'push', 'fix-push', 'pr-wait', 'mark-dod'];
+
+export async function GET(
+  _req: NextRequest,
+  { params }: { params: Promise<{ projectName: string; releaseId: string }> },
+): Promise<NextResponse> {
+  const { projectName, releaseId } = await params;
+
+  const all = listJobs();
+
+  // The release meta-job
+  const releaseJob = all.find(
+    (j) => j.id === releaseId && j.project === projectName && j.kind === 'release',
+  );
+  if (!releaseJob) {
+    return NextResponse.json({ error: 'release not found' }, { status: 404 });
+  }
+
+  // All pipeline step jobs that share this releaseId
+  const stepJobs = all
+    .filter(
+      (j) =>
+        j.project === projectName &&
+        j.releaseId === releaseId &&
+        PIPELINE_STEP_KINDS.includes(j.kind),
+    )
+    .sort((a, b) => a.startedAt - b.startedAt);
+
+  // Resolve branch at release start (best-effort)
+  let branch: string | null = null;
+  const projPath = resolveProjectPath(projectName);
+  if (projPath) {
+    try {
+      const r = await exec('git', ['-C', projPath, 'rev-parse', '--abbrev-ref', 'HEAD'], {
+        timeout: 3000,
+      });
+      if (r.exitCode === 0) branch = r.stdout.trim();
+    } catch {}
+  }
+
+  const steps = stepJobs.map((j) => {
+    const verdict = getVerdict(j);
+    const rawLog = readLog(j, 3000);
+    // Last ~500 chars for the excerpt, stripped of NDJSON noise
+    const excerpt = rawLog
+      .replace(/\{"type":"[^"]+","subtype[^}]+\}/g, '')
+      .trim()
+      .slice(-500);
+
+    return {
+      job_id: j.id,
+      kind: j.kind,
+      status: j.finishedAt !== null ? ('done' as const) : ('running' as const),
+      exit_code: j.exitCode ?? null,
+      started_at: j.startedAt,
+      finished_at: j.finishedAt ?? null,
+      duration_ms: j.durationMs ?? null,
+      verdict: verdict ?? null,
+      log_excerpt: excerpt,
+    };
+  });
+
+  return NextResponse.json({
+    release_id: releaseId,
+    project: projectName,
+    branch,
+    started_at: releaseJob.startedAt,
+    finished_at: releaseJob.finishedAt ?? null,
+    exit_code: releaseJob.exitCode ?? null,
+    steps,
+  });
+}

--- a/app/project/[name]/release/[releaseId]/page.tsx
+++ b/app/project/[name]/release/[releaseId]/page.tsx
@@ -1,0 +1,10 @@
+import { ReleaseTraceView } from '@/components/ReleaseTraceView'
+
+interface Props {
+  params: Promise<{ name: string; releaseId: string }>
+}
+
+export default async function ReleasePage({ params }: Props) {
+  const { name, releaseId } = await params
+  return <ReleaseTraceView projectName={name} releaseId={releaseId} />
+}

--- a/components/ProjectDetailPage.tsx
+++ b/components/ProjectDetailPage.tsx
@@ -1398,6 +1398,11 @@ export function ProjectDetailPage({
             )
             if (!pipelineRunning) return null
 
+            // Find the active release job to link the strip to the trace view.
+            const activeReleaseJob = projectJobs
+              .filter(j => j.kind === 'release' && j.status === 'running')
+              .sort((a, b) => (b.started_at || 0) - (a.started_at || 0))[0]
+
             // Each release is a clean slate. Find the currently-running step
             // and use its start time as the anchor.
             // - Steps AFTER the running step in sequence → always pending (haven't run yet).
@@ -1658,6 +1663,15 @@ export function ProjectDetailPage({
                     </div>
                   )
                 })}
+                {activeReleaseJob && (
+                  <Link
+                    href={`/project/${encodeURIComponent(name)}/release/${encodeURIComponent(activeReleaseJob.id)}`}
+                    className="ml-auto text-[10px] text-accent hover:underline font-mono shrink-0"
+                    title="View unified release trace"
+                  >
+                    trace →
+                  </Link>
+                )}
               </div>
             )
           })()}

--- a/components/ReleaseTraceView.tsx
+++ b/components/ReleaseTraceView.tsx
@@ -1,0 +1,279 @@
+'use client'
+
+import { useState, useEffect } from 'react'
+import Link from 'next/link'
+
+interface ReleaseStep {
+  job_id: string
+  kind: string
+  status: 'running' | 'done'
+  exit_code: number | null
+  started_at: number
+  finished_at: number | null
+  duration_ms: number | null
+  verdict: string | null
+  log_excerpt: string
+}
+
+interface ReleaseTrace {
+  release_id: string
+  project: string
+  branch: string | null
+  started_at: number
+  finished_at: number | null
+  exit_code: number | null
+  steps: ReleaseStep[]
+}
+
+function formatDuration(ms: number | null): string {
+  if (ms === null || ms <= 0) return ''
+  if (ms < 1000) return `${ms}ms`
+  const s = Math.round(ms / 1000)
+  if (s < 60) return `${s}s`
+  const m = Math.floor(s / 60)
+  const rem = s % 60
+  return rem > 0 ? `${m}m ${rem}s` : `${m}m`
+}
+
+function formatTs(secs: number): string {
+  return new Date(secs * 1000).toLocaleString(undefined, {
+    month: 'short', day: 'numeric',
+    hour: '2-digit', minute: '2-digit', second: '2-digit',
+    hour12: false,
+  })
+}
+
+function StepGlyph({ step }: { step: ReleaseStep }) {
+  if (step.status === 'running') {
+    return (
+      <span className="inline-block w-4 h-4 rounded-full border-2 border-accent border-t-transparent animate-spin" />
+    )
+  }
+  if (step.exit_code === 0) {
+    return <span className="text-status-success font-bold">✓</span>
+  }
+  if (step.verdict === 'NEEDS ATTENTION') {
+    return <span className="text-status-warning font-bold">!</span>
+  }
+  if (step.verdict === 'LGTM') {
+    return <span className="text-status-success font-bold">✓</span>
+  }
+  return <span className="text-status-error font-bold">✗</span>
+}
+
+function verdictBadge(verdict: string | null) {
+  if (!verdict) return null
+  const color =
+    verdict === 'LGTM'
+      ? 'bg-status-success/15 text-status-success border-status-success/30'
+      : verdict === 'NEEDS ATTENTION'
+        ? 'bg-status-warning/15 text-status-warning border-status-warning/30'
+        : 'bg-status-error/15 text-status-error border-status-error/30'
+  return (
+    <span className={`text-[10px] px-1.5 py-0.5 rounded border font-mono ${color}`}>
+      {verdict}
+    </span>
+  )
+}
+
+interface Props {
+  projectName: string
+  releaseId: string
+}
+
+export function ReleaseTraceView({ projectName, releaseId }: Props) {
+  const [trace, setTrace] = useState<ReleaseTrace | null>(null)
+  const [error, setError] = useState<string | null>(null)
+  const [expandedStep, setExpandedStep] = useState<string | null>(null)
+
+  useEffect(() => {
+    const load = async () => {
+      try {
+        const res = await fetch(
+          `/api/projects/by-project/${encodeURIComponent(projectName)}/release/${encodeURIComponent(releaseId)}`,
+        )
+        if (!res.ok) {
+          setError(res.status === 404 ? 'Release not found' : `Error ${res.status}`)
+          return
+        }
+        setTrace(await res.json())
+      } catch {
+        setError('Failed to load release trace')
+      }
+    }
+    load()
+    // Poll while running
+    const id = setInterval(async () => {
+      try {
+        const res = await fetch(
+          `/api/projects/by-project/${encodeURIComponent(projectName)}/release/${encodeURIComponent(releaseId)}`,
+        )
+        if (!res.ok) return
+        const data: ReleaseTrace = await res.json()
+        setTrace(data)
+        if (data.finished_at !== null) clearInterval(id)
+      } catch {}
+    }, 4000)
+    return () => clearInterval(id)
+  }, [projectName, releaseId])
+
+  if (error) {
+    return (
+      <div className="p-8 text-status-error font-mono text-sm">{error}</div>
+    )
+  }
+
+  if (!trace) {
+    return (
+      <div className="p-8 text-text-tertiary font-mono text-sm animate-pulse">loading…</div>
+    )
+  }
+
+  const isRunning = trace.finished_at === null
+  const isSuccess = trace.exit_code === 0 && !isRunning
+  const isFailed = trace.exit_code !== null && trace.exit_code !== 0
+
+  const totalDurationMs = trace.finished_at
+    ? Math.round((trace.finished_at - trace.started_at) * 1000)
+    : null
+
+  return (
+    <div className="max-w-3xl mx-auto p-6 space-y-6">
+      {/* Header */}
+      <div className="rounded-lg border border-border bg-bg-secondary p-5 space-y-3">
+        <div className="flex items-start justify-between gap-4">
+          <div>
+            <div className="flex items-center gap-2 mb-1">
+              <Link
+                href={`/project/${encodeURIComponent(projectName)}`}
+                className="text-accent hover:underline font-mono text-sm"
+              >
+                {projectName}
+              </Link>
+              {trace.branch && (
+                <span className="text-text-tertiary font-mono text-xs">
+                  @ {trace.branch}
+                </span>
+              )}
+            </div>
+            <div className="text-text-tertiary text-xs font-mono">
+              Release · {releaseId.slice(-12)}
+            </div>
+          </div>
+          <div className="flex items-center gap-2 shrink-0">
+            {isRunning && (
+              <span className="flex items-center gap-1.5 text-xs px-2.5 py-1 rounded-full bg-accent/20 text-accent font-mono">
+                <span className="w-1.5 h-1.5 rounded-full bg-accent animate-pulse" />
+                running
+              </span>
+            )}
+            {isSuccess && (
+              <span className="text-xs px-2.5 py-1 rounded-full bg-status-success/15 text-status-success font-mono border border-status-success/30">
+                success
+              </span>
+            )}
+            {isFailed && (
+              <span className="text-xs px-2.5 py-1 rounded-full bg-status-error/15 text-status-error font-mono border border-status-error/30">
+                failed
+              </span>
+            )}
+          </div>
+        </div>
+        <div className="flex flex-wrap gap-4 text-xs text-text-tertiary font-mono">
+          <span>started {formatTs(trace.started_at)}</span>
+          {trace.finished_at && (
+            <span>finished {formatTs(trace.finished_at)}</span>
+          )}
+          {totalDurationMs !== null && (
+            <span>total {formatDuration(totalDurationMs)}</span>
+          )}
+          <span>{trace.steps.length} step{trace.steps.length !== 1 ? 's' : ''}</span>
+        </div>
+      </div>
+
+      {/* Timeline */}
+      {trace.steps.length === 0 ? (
+        <div className="text-text-tertiary text-sm font-mono px-2">
+          No pipeline steps recorded yet.
+        </div>
+      ) : (
+        <div className="relative">
+          {/* Vertical line */}
+          <div className="absolute left-[19px] top-4 bottom-4 w-px bg-border" />
+
+          <div className="space-y-3">
+            {trace.steps.map((step) => {
+              const isOpen = expandedStep === step.job_id
+              const dur = step.duration_ms
+                ? formatDuration(step.duration_ms)
+                : step.finished_at
+                  ? formatDuration(Math.round((step.finished_at - step.started_at) * 1000))
+                  : null
+
+              return (
+                <div key={step.job_id} className="relative pl-10">
+                  {/* Node */}
+                  <div className="absolute left-[11px] top-3 w-[18px] h-[18px] flex items-center justify-center bg-bg-primary border border-border rounded-full text-[11px]">
+                    <StepGlyph step={step} />
+                  </div>
+
+                  <div className="rounded-md border border-border bg-bg-secondary overflow-hidden">
+                    <button
+                      type="button"
+                      className="w-full flex items-center gap-3 px-4 py-3 text-left hover:bg-bg-tertiary transition-colors"
+                      onClick={() => setExpandedStep(isOpen ? null : step.job_id)}
+                    >
+                      <span className={`font-mono text-sm font-semibold w-20 shrink-0 ${
+                        step.status === 'running' ? 'text-accent' :
+                        step.exit_code === 0 || step.verdict === 'LGTM' ? 'text-text-primary' :
+                        step.verdict === 'NEEDS ATTENTION' ? 'text-status-warning' :
+                        step.exit_code !== null ? 'text-status-error' : 'text-text-secondary'
+                      }`}>
+                        {step.kind}
+                      </span>
+                      <div className="flex items-center gap-2 flex-1 min-w-0">
+                        {verdictBadge(step.verdict)}
+                        {dur && (
+                          <span className="text-[10px] text-text-tertiary font-mono">{dur}</span>
+                        )}
+                        {step.status === 'running' && (
+                          <span className="text-[10px] text-accent font-mono">running…</span>
+                        )}
+                      </div>
+                      <span className="text-[10px] text-text-tertiary font-mono shrink-0">
+                        {formatTs(step.started_at)}
+                      </span>
+                      <Link
+                        href={`/project/${encodeURIComponent(projectName)}/terminal?job=${encodeURIComponent(step.job_id)}`}
+                        className="text-[10px] text-accent hover:underline font-mono shrink-0 z-10"
+                        onClick={(e) => e.stopPropagation()}
+                      >
+                        full log →
+                      </Link>
+                      <span className={`text-text-tertiary text-xs transition-transform ${isOpen ? 'rotate-180' : ''}`}>
+                        ▾
+                      </span>
+                    </button>
+
+                    {isOpen && step.log_excerpt && (
+                      <div className="px-4 pb-3 border-t border-border">
+                        <pre className="text-[11px] text-[#c0c0c0] font-mono whitespace-pre-wrap break-words mt-2 max-h-48 overflow-y-auto leading-relaxed">
+                          {step.log_excerpt}
+                        </pre>
+                      </div>
+                    )}
+                    {isOpen && !step.log_excerpt && (
+                      <div className="px-4 pb-3 border-t border-border">
+                        <p className="text-xs text-text-tertiary font-mono mt-2">no log excerpt available</p>
+                      </div>
+                    )}
+                  </div>
+                </div>
+              )
+            })}
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/components/TerminalTab.tsx
+++ b/components/TerminalTab.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect, useRef, useCallback, useSyncExternalStore } from 'react'
 import { useRouter, useSearchParams } from 'next/navigation'
+import Link from 'next/link'
 import { runProject, fetchSkills, fetchPersonas } from '@/lib/client-api'
 import type { Skill, Persona } from '@/lib/client-api'
 import Markdown from 'react-markdown'
@@ -207,6 +208,7 @@ export function TerminalTab({ projectName, initialSessionId }: TerminalTabProps)
   )
   const [copiedIdx, setCopiedIdx] = useState<number | null>(null)
   const [autoScroll, setAutoScroll] = useState(true)
+  const [currentReleaseId, setCurrentReleaseId] = useState<string | null>(null)
   const [elapsedMs, setElapsedMs] = useState(0)
   const spinnerChars = ['⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏']
 
@@ -404,6 +406,8 @@ export function TerminalTab({ projectName, initialSessionId }: TerminalTabProps)
           router.replace(`/project/${projectName}/terminal/${data.session_id}`)
           return
         }
+        // Track the release this job belongs to (for the trace link in the header)
+        setCurrentReleaseId(data.release_id ?? null)
         const entries: TermEntry[] = []
         const kind = data.kind || jobParam.split('-').slice(1, -1).join('-')
         // `fix-push` spawns Claude directly, so its log is pure stream-json
@@ -975,6 +979,15 @@ export function TerminalTab({ projectName, initialSessionId }: TerminalTabProps)
                 <span className="w-1.5 h-1.5 rounded-full bg-status-warning animate-pulse" />
                 live
               </span>
+            )}
+            {currentReleaseId && (
+              <Link
+                href={`/project/${encodeURIComponent(projectName)}/release/${encodeURIComponent(currentReleaseId)}`}
+                className="text-[11px] px-2 py-1 h-[26px] rounded bg-[#252525] text-accent hover:text-accent/80 font-mono leading-none flex items-center"
+                title="View unified release trace"
+              >
+                trace ↗
+              </Link>
             )}
           </div>
 

--- a/lib/client-api.ts
+++ b/lib/client-api.ts
@@ -567,6 +567,7 @@ export interface JobInfo {
   log_pruned?: boolean | null
   cost_usd?: number | null
   model?: string | null
+  release_id?: string | null
 }
 
 export async function fetchJobs(project?: string): Promise<{ jobs: JobInfo[] }> {

--- a/lib/db/index.ts
+++ b/lib/db/index.ts
@@ -228,5 +228,10 @@ try {
   sqlite.exec('ALTER TABLE jobs ADD COLUMN model TEXT');
 } catch {}
 
+// Migrate: add release_id to jobs — links pipeline step jobs to their parent release
+try {
+  sqlite.exec('ALTER TABLE jobs ADD COLUMN release_id TEXT');
+} catch {}
+
 export const db = drizzle(sqlite, { schema });
 export { schema };

--- a/lib/db/migrations/0000_lush_sabretooth.sql
+++ b/lib/db/migrations/0000_lush_sabretooth.sql
@@ -1,0 +1,102 @@
+CREATE TABLE `agents` (
+	`id` text PRIMARY KEY NOT NULL,
+	`name` text NOT NULL,
+	`project` text NOT NULL,
+	`skill_ids` text DEFAULT '[]' NOT NULL,
+	`model` text DEFAULT 'sonnet' NOT NULL,
+	`prompt` text DEFAULT '' NOT NULL,
+	`schedule` text,
+	`runner` text DEFAULT 'pm2' NOT NULL,
+	`enabled` integer DEFAULT true NOT NULL,
+	`created_at` real NOT NULL,
+	`updated_at` real NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE `gh_issues_cache` (
+	`project` text PRIMARY KEY NOT NULL,
+	`repo` text NOT NULL,
+	`prs` text DEFAULT '[]' NOT NULL,
+	`issues` text DEFAULT '[]' NOT NULL,
+	`fetched_at` real NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE `gh_status` (
+	`project` text PRIMARY KEY NOT NULL,
+	`release_tag` text,
+	`ci` text,
+	`ci_failed_url` text,
+	`head_sha` text,
+	`local_head_sha` text,
+	`fetched_at` text NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE `jobs` (
+	`id` text PRIMARY KEY NOT NULL,
+	`project` text NOT NULL,
+	`kind` text NOT NULL,
+	`prompt` text,
+	`pid` integer NOT NULL,
+	`log_path` text,
+	`started_at` real NOT NULL,
+	`finished_at` real,
+	`exit_code` integer,
+	`seen` integer DEFAULT false,
+	`duration_ms` integer,
+	`input_tokens` integer,
+	`output_tokens` integer,
+	`cache_read_tokens` integer,
+	`cache_create_tokens` integer,
+	`session_id` text,
+	`user_prompt` text,
+	`context_meta` text,
+	`parent_job_id` text,
+	`gh_issue_number` integer,
+	`gh_issue_repo` text,
+	`gh_issue_title` text,
+	`log_pruned` integer DEFAULT false,
+	`cost_usd` real,
+	`model` text,
+	`release_id` text
+);
+--> statement-breakpoint
+CREATE TABLE `pipeline_locks` (
+	`project` text PRIMARY KEY NOT NULL,
+	`locked_by_job_id` text NOT NULL,
+	`acquired_at` real NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE `projects` (
+	`name` text PRIMARY KEY NOT NULL,
+	`path` text NOT NULL,
+	`enabled` integer DEFAULT false,
+	`github` text,
+	`priority` text,
+	`custom_actions` text,
+	`test_command` text,
+	`tests_disabled` integer DEFAULT false,
+	`review_disabled` integer DEFAULT false,
+	`test_cron_enabled` integer DEFAULT false,
+	`test_cron_schedule` text,
+	`auto_commit_enabled` integer DEFAULT false,
+	`auto_push_enabled` integer DEFAULT false,
+	`auto_pr_merge_enabled` integer DEFAULT false,
+	`release_after_run` integer DEFAULT false,
+	`pr_workflow_enabled` integer DEFAULT false,
+	`issue_auto_branch` integer DEFAULT true,
+	`last_push_error` text,
+	`last_push_at` real
+);
+--> statement-breakpoint
+CREATE TABLE `settings` (
+	`key` text PRIMARY KEY NOT NULL,
+	`value` text NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE `skills` (
+	`id` text PRIMARY KEY NOT NULL,
+	`name` text NOT NULL,
+	`description` text DEFAULT '' NOT NULL,
+	`content` text DEFAULT '' NOT NULL,
+	`created_at` real NOT NULL,
+	`updated_at` real NOT NULL
+);

--- a/lib/db/migrations/meta/0000_snapshot.json
+++ b/lib/db/migrations/meta/0000_snapshot.json
@@ -1,0 +1,672 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "51137f94-8d27-4def-90e3-a075f5401a21",
+  "prevId": "00000000-0000-0000-0000-000000000000",
+  "tables": {
+    "agents": {
+      "name": "agents",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project": {
+          "name": "project",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "skill_ids": {
+          "name": "skill_ids",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'sonnet'"
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "schedule": {
+          "name": "schedule",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "runner": {
+          "name": "runner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pm2'"
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "gh_issues_cache": {
+      "name": "gh_issues_cache",
+      "columns": {
+        "project": {
+          "name": "project",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "repo": {
+          "name": "repo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "prs": {
+          "name": "prs",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "issues": {
+          "name": "issues",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "fetched_at": {
+          "name": "fetched_at",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "gh_status": {
+      "name": "gh_status",
+      "columns": {
+        "project": {
+          "name": "project",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "release_tag": {
+          "name": "release_tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ci": {
+          "name": "ci",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ci_failed_url": {
+          "name": "ci_failed_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "head_sha": {
+          "name": "head_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "local_head_sha": {
+          "name": "local_head_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "fetched_at": {
+          "name": "fetched_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "jobs": {
+      "name": "jobs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project": {
+          "name": "project",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pid": {
+          "name": "pid",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "log_path": {
+          "name": "log_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "exit_code": {
+          "name": "exit_code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "seen": {
+          "name": "seen",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cache_read_tokens": {
+          "name": "cache_read_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cache_create_tokens": {
+          "name": "cache_create_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_prompt": {
+          "name": "user_prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "context_meta": {
+          "name": "context_meta",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "parent_job_id": {
+          "name": "parent_job_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "gh_issue_number": {
+          "name": "gh_issue_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "gh_issue_repo": {
+          "name": "gh_issue_repo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "gh_issue_title": {
+          "name": "gh_issue_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "log_pruned": {
+          "name": "log_pruned",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "cost_usd": {
+          "name": "cost_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "release_id": {
+          "name": "release_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "pipeline_locks": {
+      "name": "pipeline_locks",
+      "columns": {
+        "project": {
+          "name": "project",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "locked_by_job_id": {
+          "name": "locked_by_job_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "acquired_at": {
+          "name": "acquired_at",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "projects": {
+      "name": "projects",
+      "columns": {
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "github": {
+          "name": "github",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "priority": {
+          "name": "priority",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "custom_actions": {
+          "name": "custom_actions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "test_command": {
+          "name": "test_command",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tests_disabled": {
+          "name": "tests_disabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "review_disabled": {
+          "name": "review_disabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "test_cron_enabled": {
+          "name": "test_cron_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "test_cron_schedule": {
+          "name": "test_cron_schedule",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "auto_commit_enabled": {
+          "name": "auto_commit_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "auto_push_enabled": {
+          "name": "auto_push_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "auto_pr_merge_enabled": {
+          "name": "auto_pr_merge_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "release_after_run": {
+          "name": "release_after_run",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "pr_workflow_enabled": {
+          "name": "pr_workflow_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "issue_auto_branch": {
+          "name": "issue_auto_branch",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": true
+        },
+        "last_push_error": {
+          "name": "last_push_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_push_at": {
+          "name": "last_push_at",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "settings": {
+      "name": "settings",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "skills": {
+      "name": "skills",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/lib/db/migrations/meta/_journal.json
+++ b/lib/db/migrations/meta/_journal.json
@@ -1,0 +1,13 @@
+{
+  "version": "7",
+  "dialect": "sqlite",
+  "entries": [
+    {
+      "idx": 0,
+      "version": "6",
+      "when": 1777151074563,
+      "tag": "0000_lush_sabretooth",
+      "breakpoints": true
+    }
+  ]
+}

--- a/lib/db/schema.ts
+++ b/lib/db/schema.ts
@@ -53,6 +53,7 @@ export const jobs = sqliteTable('jobs', {
   logPruned: integer('log_pruned', { mode: 'boolean' }).default(false),
   costUsd: real('cost_usd'),
   model: text('model'),
+  releaseId: text('release_id'),
 });
 
 export const skills = sqliteTable('skills', {

--- a/lib/job-storage.ts
+++ b/lib/job-storage.ts
@@ -32,6 +32,7 @@ export interface JobData {
   logPruned?: boolean | null;
   costUsd?: number | null;
   model?: string | null;
+  releaseId?: string | null;
 }
 
 const jobsCache = new Map<string, JobData>();
@@ -68,6 +69,7 @@ function loadFromDb(): void {
         logPruned: row.logPruned ?? false,
         costUsd: row.costUsd ?? null,
         model: row.model ?? null,
+        releaseId: row.releaseId ?? null,
       });
     }
     loaded = true;
@@ -104,6 +106,7 @@ function saveToDb(job: JobData): void {
         logPruned: job.logPruned ?? false,
         costUsd: job.costUsd ?? null,
         model: job.model ?? null,
+        releaseId: job.releaseId ?? null,
       })
       .onConflictDoUpdate({
         target: schema.jobs.id,
@@ -124,6 +127,7 @@ function saveToDb(job: JobData): void {
           logPruned: job.logPruned ?? false,
           costUsd: job.costUsd ?? null,
           model: job.model ?? null,
+          releaseId: job.releaseId ?? null,
         },
       })
       .run();
@@ -975,6 +979,7 @@ export function jobToDict(job: JobData): Record<string, unknown> {
     gh_issue_title: job.ghIssueTitle ?? null,
   };
   d.log_pruned = job.logPruned ?? false;
+  d.release_id = job.releaseId ?? null;
   const verdict = getVerdict(job);
   if (verdict !== null) d.verdict = verdict;
   return d;
@@ -1110,6 +1115,10 @@ export function createJob(
     timestamp += 1;
     jobId = `${project}-${kind}-${timestamp}`;
   }
+  // Auto-link to the active release so every pipeline step carries releaseId.
+  // Release jobs themselves get releaseId = their own id, set explicitly by
+  // start-release.ts after creation (kind check here avoids circular reference).
+  const autoReleaseId = kind !== 'release' ? (findActiveReleaseJob(project)?.id ?? null) : null;
   const job: JobData = {
     id: jobId,
     project,
@@ -1132,6 +1141,7 @@ export function createJob(
     ghIssueNumber: ghIssueNumber ?? null,
     ghIssueRepo: ghIssueRepo ?? null,
     ghIssueTitle: ghIssueTitle ?? null,
+    releaseId: autoReleaseId,
   };
   jobsCache.set(jobId, job);
   saveToDb(job);
@@ -1173,6 +1183,7 @@ export function getJob(jobId: string): JobData | null {
     logPruned: row.logPruned ?? false,
     costUsd: row.costUsd ?? null,
     model: row.model ?? null,
+    releaseId: row.releaseId ?? null,
   };
   jobsCache.set(jobId, job);
   return job;

--- a/lib/start-release.ts
+++ b/lib/start-release.ts
@@ -32,7 +32,7 @@ export type ReleaseResult =
 // The monitor polls the release log for the "# release finished" marker
 // written by finalizeReleaseJob() and exits with the embedded exit code,
 // giving the release job a real pid and PM2-managed lifecycle.
-async function createReleaseJob(projectName: string): Promise<{ id: string; logPath: string } | null> {
+async function createReleaseJob(projectName: string): Promise<{ id: string; releaseId: string; logPath: string } | null> {
   try {
     const { logDir } = getImproveConfig();
     mkdirSync(logDir, { recursive: true });
@@ -42,6 +42,9 @@ async function createReleaseJob(projectName: string): Promise<{ id: string; logP
     const scriptPath = join(logDir, `${job.id}.sh`);
     const monitorLogPath = join(logDir, `${job.id}.monitor.log`);
     job.logPath = logPath;
+    // Release job identifies itself: every child step created while this
+    // release is active will auto-inherit this id as its releaseId.
+    job.releaseId = job.id;
 
     appendFileSync(logPath, `# release start — ${new Date().toISOString()}\n# project: ${projectName}\n`);
 
@@ -109,7 +112,7 @@ async function createReleaseJob(projectName: string): Promise<{ id: string; logP
 
     job.pid = pid;
     updateJob(job);
-    return { id: job.id, logPath };
+    return { id: job.id, releaseId: job.id, logPath };
   } catch {
     return null;
   }


### PR DESCRIPTION
Closes #42

Implemented via TamTam from issue [#42](https://github.com/3h4x/tamtam/issues/42).