### PR TITLE
fix: Add pipeline-level abort so a runaway release can be stopped cleanly

### DIFF
--- a/__tests__/api/release-abort.test.ts
+++ b/__tests__/api/release-abort.test.ts
@@ -1,0 +1,187 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { NextRequest } from 'next/server';
+import type { JobData } from '@/lib/job-storage';
+import type { PipelineLock } from '@/lib/pipeline-lock';
+
+function makeJob(overrides: Partial<JobData> = {}): JobData {
+  return {
+    id: 'release-1',
+    project: 'proj1',
+    kind: 'release',
+    prompt: null,
+    pid: 0,
+    logPath: null,
+    startedAt: 1000,
+    finishedAt: null,
+    exitCode: null,
+    seen: false,
+    abortedAt: null,
+    ...overrides,
+  };
+}
+
+function makeLock(overrides: Partial<PipelineLock> = {}): PipelineLock {
+  return {
+    project: 'proj1',
+    lockedByJobId: 'release-1',
+    acquiredAt: 1000,
+    ...overrides,
+  };
+}
+
+describe('POST /api/projects/by-project/{projectName}/release/abort', () => {
+  let POST: (req: NextRequest, ctx: { params: Promise<{ projectName: string }> }) => Promise<Response>;
+  let getLockMock: ReturnType<typeof vi.fn>;
+  let releaseLockMock: ReturnType<typeof vi.fn>;
+  let getJobMock: ReturnType<typeof vi.fn>;
+  let listJobsMock: ReturnType<typeof vi.fn>;
+  let updateJobMock: ReturnType<typeof vi.fn>;
+  let execMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(async () => {
+    vi.resetModules();
+
+    getLockMock = vi.fn().mockReturnValue(null);
+    releaseLockMock = vi.fn();
+    getJobMock = vi.fn().mockReturnValue(null);
+    listJobsMock = vi.fn().mockReturnValue([]);
+    updateJobMock = vi.fn();
+    execMock = vi.fn().mockResolvedValue({ exitCode: 0, stdout: '', stderr: '' });
+
+    vi.doMock('@/lib/pipeline-lock', () => ({
+      getLock: getLockMock,
+      releaseLock: releaseLockMock,
+    }));
+    vi.doMock('@/lib/job-storage', () => ({
+      getJob: getJobMock,
+      listJobs: listJobsMock,
+      updateJob: updateJobMock,
+    }));
+    vi.doMock('@/lib/shell', () => ({ exec: execMock }));
+    vi.doMock('@/lib/notifications', () => ({ notify: vi.fn().mockResolvedValue(undefined) }));
+
+    const mod = await import('@/app/api/projects/by-project/[projectName]/release/abort/route');
+    POST = mod.POST;
+  });
+
+  afterEach(() => {
+    vi.resetModules();
+  });
+
+  function req(name = 'proj1') {
+    return new NextRequest(`http://localhost/api/projects/by-project/${name}/release/abort`, {
+      method: 'POST',
+    });
+  }
+
+  it('returns no_pipeline when no lock exists', async () => {
+    getLockMock.mockReturnValue(null);
+    const res = await POST(req(), { params: Promise.resolve({ projectName: 'proj1' }) });
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.status).toBe('no_pipeline');
+  });
+
+  it('returns no_pipeline and releases lock when release already finished', async () => {
+    getLockMock.mockReturnValue(makeLock());
+    getJobMock.mockReturnValue(makeJob({ finishedAt: 2000, exitCode: 0 }));
+
+    const res = await POST(req(), { params: Promise.resolve({ projectName: 'proj1' }) });
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.status).toBe('no_pipeline');
+    expect(releaseLockMock).toHaveBeenCalledWith('proj1', 'release-1');
+  });
+
+  it('aborts a running release with no active step job', async () => {
+    getLockMock.mockReturnValue(makeLock());
+    const releaseJob = makeJob();
+    getJobMock.mockReturnValue(releaseJob);
+    listJobsMock.mockReturnValue([releaseJob]);
+
+    const res = await POST(req(), { params: Promise.resolve({ projectName: 'proj1' }) });
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.status).toBe('aborted');
+    expect(data.release_id).toBe('release-1');
+    expect(data.killed_job_id).toBeNull();
+
+    // Release job should be marked aborted
+    expect(releaseJob.abortedAt).not.toBeNull();
+    expect(releaseJob.finishedAt).not.toBeNull();
+    expect(releaseJob.exitCode).toBe(-3);
+    expect(updateJobMock).toHaveBeenCalledWith(releaseJob);
+
+    // Lock released
+    expect(releaseLockMock).toHaveBeenCalledWith('proj1', 'release-1');
+  });
+
+  it('kills the running step job and marks it aborted', async () => {
+    getLockMock.mockReturnValue(makeLock());
+    const releaseJob = makeJob();
+    const stepJob = makeJob({
+      id: 'review-1',
+      kind: 'review',
+      pid: 1234,
+      releaseId: 'release-1',
+      finishedAt: null,
+    });
+    getJobMock.mockReturnValue(releaseJob);
+    listJobsMock.mockReturnValue([releaseJob, stepJob]);
+
+    const res = await POST(req(), { params: Promise.resolve({ projectName: 'proj1' }) });
+    const data = await res.json();
+    expect(data.status).toBe('aborted');
+    expect(data.killed_job_id).toBe('review-1');
+
+    // Step job should be marked aborted
+    expect(stepJob.abortedAt).not.toBeNull();
+    expect(stepJob.finishedAt).not.toBeNull();
+    expect(stepJob.exitCode).toBe(-3);
+    expect(updateJobMock).toHaveBeenCalledWith(stepJob);
+
+    // pm2 stop/delete attempted on the step job
+    expect(execMock).toHaveBeenCalledWith('pm2', ['stop', 'review-1', '--silent'], expect.any(Object));
+    expect(execMock).toHaveBeenCalledWith('pm2', ['delete', 'review-1', '--silent'], expect.any(Object));
+
+    // Lock released
+    expect(releaseLockMock).toHaveBeenCalledWith('proj1', 'release-1');
+  });
+
+  it('does not kill an already-finished step job', async () => {
+    getLockMock.mockReturnValue(makeLock());
+    const releaseJob = makeJob();
+    const stepJob = makeJob({
+      id: 'push-1',
+      kind: 'push',
+      pid: 999,
+      releaseId: 'release-1',
+      finishedAt: 1500, // already done
+      exitCode: 0,
+    });
+    getJobMock.mockReturnValue(releaseJob);
+    listJobsMock.mockReturnValue([releaseJob, stepJob]);
+
+    const res = await POST(req(), { params: Promise.resolve({ projectName: 'proj1' }) });
+    const data = await res.json();
+    expect(data.status).toBe('aborted');
+    // Finished step is not the running one
+    expect(data.killed_job_id).toBeNull();
+    expect(execMock).not.toHaveBeenCalled();
+  });
+
+  it('still releases lock even when pm2 stop throws', async () => {
+    getLockMock.mockReturnValue(makeLock());
+    const releaseJob = makeJob();
+    const stepJob = makeJob({ id: 'fix-1', kind: 'fix', pid: 42, releaseId: 'release-1', finishedAt: null });
+    getJobMock.mockReturnValue(releaseJob);
+    listJobsMock.mockReturnValue([releaseJob, stepJob]);
+    execMock.mockRejectedValue(new Error('pm2 not found'));
+
+    const res = await POST(req(), { params: Promise.resolve({ projectName: 'proj1' }) });
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.status).toBe('aborted');
+    expect(releaseLockMock).toHaveBeenCalledWith('proj1', 'release-1');
+  });
+});

--- a/__tests__/lib/config.test.ts
+++ b/__tests__/lib/config.test.ts
@@ -74,6 +74,7 @@ describe('config', () => {
         notification_webhook_secret: '',
         notification_on_release_success: false,
         notification_on_release_fail: false,
+        notification_on_release_aborted: false,
         notification_on_fix_loop_exhausted: false,
         notification_on_review_do_not_ship: false,
         notification_on_agent_run_fail: false,

--- a/__tests__/lib/job-storage-mark-dod.test.ts
+++ b/__tests__/lib/job-storage-mark-dod.test.ts
@@ -38,7 +38,8 @@ function createTestDb() {
       log_pruned INTEGER DEFAULT 0,
       cost_usd REAL,
       model TEXT,
-      release_id TEXT
+      release_id TEXT,
+      aborted_at REAL
     );
     CREATE TABLE IF NOT EXISTS gh_issues_cache (
       project TEXT PRIMARY KEY,

--- a/__tests__/lib/job-storage.test.ts
+++ b/__tests__/lib/job-storage.test.ts
@@ -40,7 +40,8 @@ function createTestDb() {
       log_pruned INTEGER DEFAULT 0,
       cost_usd REAL,
       model TEXT,
-      release_id TEXT
+      release_id TEXT,
+      aborted_at REAL
     );
     CREATE TABLE IF NOT EXISTS gh_issues_cache (
       project TEXT PRIMARY KEY,
@@ -3154,5 +3155,115 @@ describe('markDone – DB-level idempotency guard', () => {
     // In-memory guard should have returned before any DB interaction
     expect(job.finishedAt).toBe(snapshotFinishedAt); // unchanged
     expect(job.exitCode).toBeNull(); // not overwritten
+  });
+});
+
+describe('runCompletionHooks – abort short-circuit', () => {
+  let testDb: ReturnType<typeof createTestDb>;
+  let markDoneFn: typeof import('@/lib/job-storage').markDone;
+  let startProjectReviewMock: ReturnType<typeof vi.fn>;
+  let startProjectPushMock: ReturnType<typeof vi.fn>;
+  let startProjectCommitMock: ReturnType<typeof vi.fn>;
+  let startFixFromJobMock: ReturnType<typeof vi.fn>;
+  let getProjectTestConfigMock: ReturnType<typeof vi.fn>;
+
+  function makeJob(kind: string, id?: string, overrides: Partial<JobData> = {}): JobData {
+    return {
+      id: id ?? `${kind}-job`,
+      project: 'abort-proj',
+      kind,
+      prompt: null,
+      pid: 100,
+      logPath: null,
+      startedAt: Date.now() / 1000,
+      finishedAt: null,
+      exitCode: null,
+      seen: false,
+      durationMs: null,
+      inputTokens: null,
+      outputTokens: null,
+      cacheReadTokens: null,
+      cacheCreateTokens: null,
+      sessionId: null,
+      ...overrides,
+    };
+  }
+
+  beforeEach(async () => {
+    vi.resetModules();
+    testDb = createTestDb();
+
+    startProjectReviewMock = vi.fn().mockResolvedValue({ ok: true, jobId: 'rev-1' });
+    startProjectPushMock = vi.fn().mockResolvedValue({ ok: true });
+    startProjectCommitMock = vi.fn().mockResolvedValue({ ok: true, commitSha: 'abc' });
+    startFixFromJobMock = vi.fn().mockResolvedValue({ ok: true, jobId: 'fix-1' });
+    getProjectTestConfigMock = vi.fn().mockReturnValue({ autoPushEnabled: true });
+
+    vi.doMock('@/lib/db', () => ({ db: testDb.db, schema }));
+    vi.doMock('@/lib/pm2-jobs', () => ({
+      getJobStatus: vi.fn(),
+      deleteJob: vi.fn().mockResolvedValue(undefined),
+    }));
+    vi.doMock('@/lib/shell', () => ({
+      exec: vi.fn().mockResolvedValue({ exitCode: 0, stdout: '', stderr: '' }),
+    }));
+    vi.doMock('@/lib/git-utils', () => ({
+      markReviewed: vi.fn().mockResolvedValue(undefined),
+    }));
+    vi.doMock('@/lib/project-data', () => ({
+      resolveProjectPath: vi.fn().mockReturnValue('/proj'),
+    }));
+    vi.doMock('@/lib/start-review', () => ({ startProjectReview: startProjectReviewMock }));
+    vi.doMock('@/lib/start-push', () => ({ startProjectPush: startProjectPushMock }));
+    vi.doMock('@/lib/start-commit', () => ({ startProjectCommit: startProjectCommitMock }));
+    vi.doMock('@/lib/start-fix', () => ({ startFixFromJob: startFixFromJobMock }));
+    vi.doMock('@/lib/scheduling', () => ({
+      getProjectTestConfig: getProjectTestConfigMock,
+    }));
+
+    const mod = await import('@/lib/job-storage');
+    markDoneFn = mod.markDone;
+  });
+
+  afterEach(() => {
+    vi.resetModules();
+  });
+
+  it('does not chain to next step when active release has abortedAt set', async () => {
+    const now = Date.now() / 1000;
+    // Insert an aborted release job — finishedAt is set (as the abort handler does)
+    testDb.db.insert(schema.jobs).values({
+      id: 'release-aborted', project: 'abort-proj', kind: 'release',
+      prompt: null, pid: 0, logPath: null,
+      startedAt: now - 30, finishedAt: now - 1, exitCode: -3,
+      seen: 0, durationMs: null, inputTokens: null, outputTokens: null,
+      cacheReadTokens: null, cacheCreateTokens: null, sessionId: null,
+      abortedAt: now - 1,
+    } as any).run();
+
+    // Step job must carry releaseId so the abort check can find the release
+    const reviewJob = makeJob('review', 'review-after-abort', { releaseId: 'release-aborted' });
+    await markDoneFn(reviewJob, 0);
+
+    expect(startProjectCommitMock).not.toHaveBeenCalled();
+    expect(startProjectPushMock).not.toHaveBeenCalled();
+    expect(startFixFromJobMock).not.toHaveBeenCalled();
+  });
+
+  it('does not chain fix→review when active release is aborted', async () => {
+    const now = Date.now() / 1000;
+    testDb.db.insert(schema.jobs).values({
+      id: 'release-aborted-2', project: 'abort-proj', kind: 'release',
+      prompt: null, pid: 0, logPath: null,
+      startedAt: now - 30, finishedAt: now - 1, exitCode: -3,
+      seen: 0, durationMs: null, inputTokens: null, outputTokens: null,
+      cacheReadTokens: null, cacheCreateTokens: null, sessionId: null,
+      abortedAt: now - 1,
+    } as any).run();
+
+    const fixJob = makeJob('fix', 'fix-after-abort', { releaseId: 'release-aborted-2' });
+    await markDoneFn(fixJob, 0);
+
+    expect(startProjectReviewMock).not.toHaveBeenCalled();
   });
 });

--- a/__tests__/lib/pipeline-lock.test.ts
+++ b/__tests__/lib/pipeline-lock.test.ts
@@ -37,7 +37,8 @@ function createTestDb() {
       log_pruned INTEGER DEFAULT 0,
       cost_usd REAL,
       model TEXT,
-      release_id TEXT
+      release_id TEXT,
+      aborted_at REAL
     );
   `);
   return { sqlite, db: drizzle(sqlite, { schema }) };

--- a/__tests__/lib/retention.test.ts
+++ b/__tests__/lib/retention.test.ts
@@ -37,7 +37,8 @@ function createTestDb() {
       log_pruned INTEGER DEFAULT 0,
       cost_usd REAL,
       model TEXT,
-      release_id TEXT
+      release_id TEXT,
+      aborted_at REAL
     );
   `);
   return { sqlite, db: drizzle(sqlite, { schema }) };

--- a/app/api/projects/by-project/[projectName]/release/abort/route.ts
+++ b/app/api/projects/by-project/[projectName]/release/abort/route.ts
@@ -1,0 +1,85 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getLock, releaseLock } from '@/lib/pipeline-lock';
+import { getJob, listJobs, updateJob } from '@/lib/job-storage';
+import { exec } from '@/lib/shell';
+
+export async function POST(
+  _request: NextRequest,
+  { params }: { params: Promise<{ projectName: string }> }
+) {
+  const { projectName } = await params;
+
+  const lock = getLock(projectName);
+  if (!lock) {
+    return NextResponse.json({ status: 'no_pipeline', detail: 'no active pipeline lock' }, { status: 200 });
+  }
+
+  const releaseJob = getJob(lock.lockedByJobId);
+  if (!releaseJob || releaseJob.kind !== 'release' || releaseJob.finishedAt !== null) {
+    // Lock exists but release is already done — just clean up the lock
+    releaseLock(projectName, lock.lockedByJobId);
+    return NextResponse.json({ status: 'no_pipeline', detail: 'release already finished' }, { status: 200 });
+  }
+
+  const now = Date.now() / 1000;
+
+  // Mark the release job as aborted so completion hooks short-circuit
+  releaseJob.abortedAt = now;
+  releaseJob.finishedAt = now;
+  releaseJob.exitCode = -3;
+  updateJob(releaseJob);
+  if (releaseJob.logPath) {
+    try {
+      const { appendFileSync } = await import('fs');
+      appendFileSync(releaseJob.logPath, `\n# release aborted by user — ${new Date().toISOString()}\n`);
+    } catch {}
+  }
+
+  // Find and kill the currently-running pipeline step job for this release
+  const runningStep = listJobs().find(
+    j => j.releaseId === releaseJob.id && j.finishedAt === null && j.kind !== 'release'
+  );
+
+  if (runningStep) {
+    // Try pm2 stop first
+    try {
+      await exec('pm2', ['stop', runningStep.id, '--silent'], { timeout: 5000 });
+      await exec('pm2', ['delete', runningStep.id, '--silent'], { timeout: 5000 });
+    } catch {}
+
+    // Kill by PID as fallback
+    if (runningStep.pid > 0) {
+      try { process.kill(runningStep.pid, 'SIGTERM'); } catch {}
+      setTimeout(() => {
+        try { process.kill(runningStep.pid, 'SIGKILL'); } catch {}
+      }, 2000);
+    }
+
+    runningStep.abortedAt = now;
+    runningStep.finishedAt = now;
+    runningStep.exitCode = -3;
+    updateJob(runningStep);
+  }
+
+  // Always release the pipeline lock
+  releaseLock(projectName, lock.lockedByJobId);
+
+  // Fire-and-forget notification
+  try {
+    const { notify } = await import('@/lib/notifications');
+    await notify({
+      event: 'release_aborted',
+      project: projectName,
+      job_id: releaseJob.id,
+      status: 'failed',
+      log_url: `${process.env.TAMTAM_BASE_URL || 'http://localhost:1337'}/project/${encodeURIComponent(projectName)}/history`,
+      timestamp: Date.now(),
+    });
+  } catch {}
+
+  return NextResponse.json({
+    status: 'aborted',
+    release_id: releaseJob.id,
+    killed_job_id: runningStep?.id ?? null,
+  });
+}

--- a/app/api/settings/route.ts
+++ b/app/api/settings/route.ts
@@ -27,6 +27,7 @@ const SETTING_KEYS = [
   'notification_webhook_secret',
   'notification_on_release_success',
   'notification_on_release_fail',
+  'notification_on_release_aborted',
   'notification_on_fix_loop_exhausted',
   'notification_on_review_do_not_ship',
   'notification_on_agent_run_fail',

--- a/components/ProjectDetailPage.tsx
+++ b/components/ProjectDetailPage.tsx
@@ -290,6 +290,7 @@ export function ProjectDetailPage({
   const [fixingCi, setFixingCi] = useState(false)
   const [fixCiResult, setFixCiResult] = useState<string | null>(null)
   const [retryingPush, setRetryingPush] = useState(false)
+  const [aborting, setAborting] = useState(false)
   const [projectJobs, setProjectJobs] = useState<JobInfo[]>([])
   const [issueCount, setIssueCount] = useState<{ prs: number; issues: number } | null>(null)
   const [currentBranch, setCurrentBranch] = useState<string | null>(null)
@@ -1615,6 +1616,26 @@ export function ProjectDetailPage({
               }
             }
 
+            const handleAbortPipeline = async () => {
+              if (aborting) return
+              if (!confirm('Abort the running pipeline? The current step will be killed and no further steps will run.')) return
+              setAborting(true)
+              try {
+                const res = await fetch(`/api/projects/by-project/${encodeURIComponent(name)}/release/abort`, { method: 'POST' })
+                const data = await res.json() as { status: string }
+                if (data.status === 'aborted') {
+                  toast('Pipeline aborted', 'success')
+                } else {
+                  toast('No active pipeline', 'info')
+                }
+                onRefresh()
+              } catch (err) {
+                toast(err instanceof Error ? err.message : 'Abort failed', 'error')
+              } finally {
+                setAborting(false)
+              }
+            }
+
             const steps: Array<{ label: string; state: StepState; hint: string; action?: (() => void) | null; retryAction?: (() => void) | null }> = []
             if (hasTestCommand) steps.push({ label: 'test', state: testState, hint: testHint, action: testJob ? () => router.push(`/project/${name}/terminal?job=${encodeURIComponent(testJob.id)}`) : null })
             steps.push({ label: 'review', state: reviewState, hint: reviewHint, action: reviewFixAction })
@@ -1682,6 +1703,15 @@ export function ProjectDetailPage({
                     trace →
                   </Link>
                 )}
+                <button
+                  type="button"
+                  className="text-[10px] px-2 py-0.5 rounded border border-status-error/50 text-status-error hover:bg-status-error/10 cursor-pointer disabled:opacity-50 font-mono leading-none shrink-0"
+                  onClick={handleAbortPipeline}
+                  disabled={aborting}
+                  title="Abort the running pipeline"
+                >
+                  {aborting ? '…' : 'abort'}
+                </button>
               </div>
             )
           })()}

--- a/components/SettingsPage.tsx
+++ b/components/SettingsPage.tsx
@@ -28,6 +28,7 @@ interface SettingsMap {
   notification_webhook_secret: string
   notification_on_release_success: string
   notification_on_release_fail: string
+  notification_on_release_aborted: string
   notification_on_fix_loop_exhausted: string
   notification_on_review_do_not_ship: string
   notification_on_agent_run_fail: string
@@ -72,6 +73,7 @@ const DEFAULTS: SettingsMap = {
   notification_webhook_secret: '',
   notification_on_release_success: 'false',
   notification_on_release_fail: 'false',
+  notification_on_release_aborted: 'false',
   notification_on_fix_loop_exhausted: 'false',
   notification_on_review_do_not_ship: 'false',
   notification_on_agent_run_fail: 'false',
@@ -229,6 +231,12 @@ const FIELDS: Record<keyof SettingsMap, FieldDef> = {
   },
   notification_on_release_fail: {
     label: 'Notification on Release Fail',
+    help: 'Not used in FIELDS; handled by NotificationsTab',
+    group: 'notifications' as never,
+    span: 1,
+  },
+  notification_on_release_aborted: {
+    label: 'Notification on Release Aborted',
     help: 'Not used in FIELDS; handled by NotificationsTab',
     group: 'notifications' as never,
     span: 1,
@@ -529,6 +537,7 @@ function NotificationsTab({
   const eventToggles = [
     { key: 'notification_on_release_success' as const, label: 'Release Success', description: 'When a release pipeline completes successfully' },
     { key: 'notification_on_release_fail' as const, label: 'Release Failure', description: 'When a release pipeline fails' },
+    { key: 'notification_on_release_aborted' as const, label: 'Release Aborted', description: 'When a release pipeline is aborted mid-run' },
     { key: 'notification_on_fix_loop_exhausted' as const, label: 'Fix Loop Exhausted', description: 'When the fix loop reaches its retry limit' },
     { key: 'notification_on_review_do_not_ship' as const, label: 'Review: Do Not Ship', description: 'When a review verdict is "DO NOT SHIP"' },
     { key: 'notification_on_agent_run_fail' as const, label: 'Agent Run Failure', description: 'When an agent run fails' },

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -29,6 +29,7 @@ export interface TamTamConfig {
   notification_webhook_secret: string;
   notification_on_release_success: boolean;
   notification_on_release_fail: boolean;
+  notification_on_release_aborted: boolean;
   notification_on_fix_loop_exhausted: boolean;
   notification_on_review_do_not_ship: boolean;
   notification_on_agent_run_fail: boolean;
@@ -63,6 +64,7 @@ const DEFAULTS: TamTamConfig = {
   notification_webhook_secret: '',
   notification_on_release_success: false,
   notification_on_release_fail: false,
+  notification_on_release_aborted: false,
   notification_on_fix_loop_exhausted: false,
   notification_on_review_do_not_ship: false,
   notification_on_agent_run_fail: false,
@@ -103,6 +105,7 @@ export function getSettings(): TamTamConfig {
     notification_webhook_secret: map.notification_webhook_secret ?? DEFAULTS.notification_webhook_secret,
     notification_on_release_success: map.notification_on_release_success === 'true',
     notification_on_release_fail: map.notification_on_release_fail === 'true',
+    notification_on_release_aborted: map.notification_on_release_aborted === 'true',
     notification_on_fix_loop_exhausted: map.notification_on_fix_loop_exhausted === 'true',
     notification_on_review_do_not_ship: map.notification_on_review_do_not_ship === 'true',
     notification_on_agent_run_fail: map.notification_on_agent_run_fail === 'true',

--- a/lib/db/index.ts
+++ b/lib/db/index.ts
@@ -233,5 +233,10 @@ try {
   sqlite.exec('ALTER TABLE jobs ADD COLUMN release_id TEXT');
 } catch {}
 
+// Migrate: add aborted_at to jobs — set when a release pipeline is aborted mid-run
+try {
+  sqlite.exec('ALTER TABLE jobs ADD COLUMN aborted_at REAL');
+} catch {}
+
 export const db = drizzle(sqlite, { schema });
 export { schema };

--- a/lib/db/migrations/0001_rare_wong.sql
+++ b/lib/db/migrations/0001_rare_wong.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `jobs` ADD `aborted_at` real;

--- a/lib/db/migrations/meta/0001_snapshot.json
+++ b/lib/db/migrations/meta/0001_snapshot.json
@@ -1,0 +1,679 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "b8dc9e57-d945-495f-8148-55fdbbb215b2",
+  "prevId": "51137f94-8d27-4def-90e3-a075f5401a21",
+  "tables": {
+    "agents": {
+      "name": "agents",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project": {
+          "name": "project",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "skill_ids": {
+          "name": "skill_ids",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'sonnet'"
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "schedule": {
+          "name": "schedule",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "runner": {
+          "name": "runner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pm2'"
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "gh_issues_cache": {
+      "name": "gh_issues_cache",
+      "columns": {
+        "project": {
+          "name": "project",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "repo": {
+          "name": "repo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "prs": {
+          "name": "prs",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "issues": {
+          "name": "issues",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "fetched_at": {
+          "name": "fetched_at",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "gh_status": {
+      "name": "gh_status",
+      "columns": {
+        "project": {
+          "name": "project",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "release_tag": {
+          "name": "release_tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ci": {
+          "name": "ci",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ci_failed_url": {
+          "name": "ci_failed_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "head_sha": {
+          "name": "head_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "local_head_sha": {
+          "name": "local_head_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "fetched_at": {
+          "name": "fetched_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "jobs": {
+      "name": "jobs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project": {
+          "name": "project",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pid": {
+          "name": "pid",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "log_path": {
+          "name": "log_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "exit_code": {
+          "name": "exit_code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "seen": {
+          "name": "seen",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cache_read_tokens": {
+          "name": "cache_read_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cache_create_tokens": {
+          "name": "cache_create_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_prompt": {
+          "name": "user_prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "context_meta": {
+          "name": "context_meta",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "parent_job_id": {
+          "name": "parent_job_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "gh_issue_number": {
+          "name": "gh_issue_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "gh_issue_repo": {
+          "name": "gh_issue_repo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "gh_issue_title": {
+          "name": "gh_issue_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "log_pruned": {
+          "name": "log_pruned",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "cost_usd": {
+          "name": "cost_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "release_id": {
+          "name": "release_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "aborted_at": {
+          "name": "aborted_at",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "pipeline_locks": {
+      "name": "pipeline_locks",
+      "columns": {
+        "project": {
+          "name": "project",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "locked_by_job_id": {
+          "name": "locked_by_job_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "acquired_at": {
+          "name": "acquired_at",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "projects": {
+      "name": "projects",
+      "columns": {
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "github": {
+          "name": "github",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "priority": {
+          "name": "priority",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "custom_actions": {
+          "name": "custom_actions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "test_command": {
+          "name": "test_command",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tests_disabled": {
+          "name": "tests_disabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "review_disabled": {
+          "name": "review_disabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "test_cron_enabled": {
+          "name": "test_cron_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "test_cron_schedule": {
+          "name": "test_cron_schedule",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "auto_commit_enabled": {
+          "name": "auto_commit_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "auto_push_enabled": {
+          "name": "auto_push_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "auto_pr_merge_enabled": {
+          "name": "auto_pr_merge_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "release_after_run": {
+          "name": "release_after_run",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "pr_workflow_enabled": {
+          "name": "pr_workflow_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "issue_auto_branch": {
+          "name": "issue_auto_branch",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": true
+        },
+        "last_push_error": {
+          "name": "last_push_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_push_at": {
+          "name": "last_push_at",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "settings": {
+      "name": "settings",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "skills": {
+      "name": "skills",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/lib/db/migrations/meta/_journal.json
+++ b/lib/db/migrations/meta/_journal.json
@@ -8,6 +8,13 @@
       "when": 1777151074563,
       "tag": "0000_lush_sabretooth",
       "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "6",
+      "when": 1777215155487,
+      "tag": "0001_rare_wong",
+      "breakpoints": true
     }
   ]
 }

--- a/lib/db/schema.ts
+++ b/lib/db/schema.ts
@@ -54,6 +54,7 @@ export const jobs = sqliteTable('jobs', {
   costUsd: real('cost_usd'),
   model: text('model'),
   releaseId: text('release_id'),
+  abortedAt: real('aborted_at'),
 });
 
 export const skills = sqliteTable('skills', {

--- a/lib/job-storage.ts
+++ b/lib/job-storage.ts
@@ -33,6 +33,7 @@ export interface JobData {
   costUsd?: number | null;
   model?: string | null;
   releaseId?: string | null;
+  abortedAt?: number | null;
 }
 
 const jobsCache = new Map<string, JobData>();
@@ -70,6 +71,7 @@ function loadFromDb(): void {
         costUsd: row.costUsd ?? null,
         model: row.model ?? null,
         releaseId: row.releaseId ?? null,
+        abortedAt: row.abortedAt ?? null,
       });
     }
     loaded = true;
@@ -107,6 +109,7 @@ function saveToDb(job: JobData): void {
         costUsd: job.costUsd ?? null,
         model: job.model ?? null,
         releaseId: job.releaseId ?? null,
+        abortedAt: job.abortedAt ?? null,
       })
       .onConflictDoUpdate({
         target: schema.jobs.id,
@@ -128,6 +131,7 @@ function saveToDb(job: JobData): void {
           costUsd: job.costUsd ?? null,
           model: job.model ?? null,
           releaseId: job.releaseId ?? null,
+          abortedAt: job.abortedAt ?? null,
         },
       })
       .run();
@@ -406,6 +410,18 @@ async function runCompletionHooks(job: JobData): Promise<void> {
   if (['test', 'review', 'fix', 'commit', 'push', 'fix-push', 'pr-wait', 'mark-dod'].includes(job.kind)) {
     const release = findActiveReleaseJob(job.project);
     if (release) appendToReleaseLog(release, job.kind, job);
+  }
+
+  // If the release was aborted while this step was running, do not chain to
+  // the next step. The abort handler sets finishedAt on the release job, so
+  // findActiveReleaseJob (which filters finishedAt === null) won't find it.
+  // Use job.releaseId + getJob() to check the abortedAt flag directly.
+  if (job.releaseId) {
+    const releaseForAbortCheck = getJob(job.releaseId);
+    if (releaseForAbortCheck?.abortedAt) {
+      console.log(`[release] job ${job.id} (${job.kind}) completed after abort — not chaining`);
+      return;
+    }
   }
 
   // Tracks whether this hook kicked off a downstream step. If not, the
@@ -959,7 +975,8 @@ export function jobToDict(job: JobData): Record<string, unknown> {
     prompt: job.prompt,
     pid: job.pid,
     log_path: job.logPath,
-    status: job.finishedAt !== null ? 'done' : 'running',
+    status: job.abortedAt !== null && job.abortedAt !== undefined ? 'aborted' : job.finishedAt !== null ? 'done' : 'running',
+    aborted_at: job.abortedAt ?? null,
     exit_code: job.exitCode,
     started_at: job.startedAt,
     finished_at: job.finishedAt,
@@ -1184,6 +1201,7 @@ export function getJob(jobId: string): JobData | null {
     costUsd: row.costUsd ?? null,
     model: row.model ?? null,
     releaseId: row.releaseId ?? null,
+    abortedAt: row.abortedAt ?? null,
   };
   jobsCache.set(jobId, job);
   return job;

--- a/lib/notifications.ts
+++ b/lib/notifications.ts
@@ -4,6 +4,7 @@ import { getSettings } from './config';
 export type NotificationEvent =
   | 'release_success'
   | 'release_fail'
+  | 'release_aborted'
   | 'fix_loop_exhausted'
   | 'review_do_not_ship'
   | 'agent_run_fail';
@@ -40,6 +41,9 @@ function getNotificationConfig(event: NotificationEvent): NotificationConfig {
       break;
     case 'release_fail':
       enabled = settings.notification_on_release_fail || false;
+      break;
+    case 'release_aborted':
+      enabled = settings.notification_on_release_aborted || false;
       break;
     case 'fix_loop_exhausted':
       enabled = settings.notification_on_fix_loop_exhausted || false;

--- a/lib/start-mark-dod.ts
+++ b/lib/start-mark-dod.ts
@@ -192,7 +192,7 @@ JSON schema:
         '--model', 'haiku',
         '-p', prompt,
       ],
-      { cwd: projPath, timeout: 180000 },
+      { cwd: projPath, timeout: 180000, killProcessGroup: true },
     );
     log(`# claude exit ${claudeR.exitCode}\n`);
     if (claudeR.exitCode !== 0 || !claudeR.stdout.trim()) {


### PR DESCRIPTION
Closes #40

Implemented via TamTam from issue [#40](https://github.com/3h4x/tamtam/issues/40).