### PR TITLE
fix: Expose trusted GitHub users as a dedicated Settings control

### DIFF
--- a/__tests__/api/issues.test.ts
+++ b/__tests__/api/issues.test.ts
@@ -222,6 +222,27 @@ describe('GET /api/projects/by-project/[projectName]/issues', () => {
     expect(data.issues[0].author.login).toBe('repo-owner');
   });
 
+  it('unions global trusted_github_users with project safe_users when trusted_only=1', async () => {
+    getSettingsMock.mockReturnValue({ trusted_github_users: ['octocat'], github_owner: '' });
+    loadFileConfigMock.mockReturnValue({ safe_users: ['repo-owner'] });
+    testDb.db.insert(schema.ghIssuesCache).values({
+      project: 'myproj',
+      repo: 'owner/myproj',
+      prs: '[]',
+      issues: JSON.stringify([
+        { number: 1, title: 'Global', author: { login: 'octocat' }, labels: [], assignees: [] },
+        { number: 2, title: 'Project', author: { login: 'repo-owner' }, labels: [], assignees: [] },
+        { number: 3, title: 'Drop', author: { login: 'outsider' }, labels: [], assignees: [] },
+      ]),
+      fetchedAt: Date.now() / 1000,
+    }).run();
+
+    const req = new NextRequest('http://localhost/api/projects/by-project/myproj/issues?trusted_only=1');
+    const res = await GET(req, { params: Promise.resolve({ projectName: 'myproj' }) });
+    const data = await res.json();
+    expect(data.issues.map((issue: { number: number }) => issue.number)).toEqual([1, 2]);
+  });
+
   it('returns no issues when neither global nor project allowlists trust any author', async () => {
     testDb.db.insert(schema.ghIssuesCache).values({
       project: 'myproj',

--- a/__tests__/api/settings.test.ts
+++ b/__tests__/api/settings.test.ts
@@ -84,6 +84,18 @@ describe('settings API', () => {
       expect(data.settings.github_owner).toBe('octocat');
     });
 
+    it('canonicalizes trusted_github_users in the API response', async () => {
+      testDb.db
+        .insert(schema.settings)
+        .values({ key: 'trusted_github_users', value: JSON.stringify(['octocat', ' hubot ', 'OctoCat']) })
+        .run();
+
+      const response = await GET();
+      const data = await response.json();
+
+      expect(data.settings.trusted_github_users).toBe('octocat, hubot');
+    });
+
     it('canonicalizes budget subscription providers in the API response', async () => {
       testDb.db
         .insert(schema.settings)
@@ -379,6 +391,51 @@ describe('settings API', () => {
 
       const row = testDb.db.select().from(schema.settings).all().find(r => r.key === 'budget_subscription_providers');
       expect(row?.value).toBe('claude,codex');
+    });
+
+    it('canonicalizes trusted_github_users before persisting them', async () => {
+      const request = new NextRequest('http://localhost/api/settings', {
+        method: 'PATCH',
+        body: JSON.stringify({ trusted_github_users: 'octocat, hubot ' }),
+      });
+      const response = await PATCH(request);
+
+      const row = testDb.db.select().from(schema.settings).all().find(r => r.key === 'trusted_github_users');
+      expect(row?.value).toBe(JSON.stringify(['octocat', 'hubot']));
+      await expect(response.json()).resolves.toMatchObject({
+        status: 'ok',
+        settings: expect.objectContaining({
+          trusted_github_users: 'octocat, hubot',
+        }),
+      });
+    });
+
+    it('rejects duplicate trusted_github_users before persisting them', async () => {
+      const request = new NextRequest('http://localhost/api/settings', {
+        method: 'PATCH',
+        body: JSON.stringify({ trusted_github_users: 'octocat, OctoCat' }),
+      });
+      const response = await PATCH(request);
+
+      expect(response.status).toBe(400);
+      await expect(response.json()).resolves.toMatchObject({
+        detail: 'Duplicate GitHub login: OctoCat',
+      });
+      expect(testDb.db.select().from(schema.settings).all()).toEqual([]);
+    });
+
+    it('rejects trusted_github_users entries with empty rows', async () => {
+      const request = new NextRequest('http://localhost/api/settings', {
+        method: 'PATCH',
+        body: JSON.stringify({ trusted_github_users: 'octocat,\n, hubot' }),
+      });
+      const response = await PATCH(request);
+
+      expect(response.status).toBe(400);
+      await expect(response.json()).resolves.toMatchObject({
+        detail: 'Trusted GitHub users cannot be empty.',
+      });
+      expect(testDb.db.select().from(schema.settings).all()).toEqual([]);
     });
 
     it('canonicalizes budget subscription providers before persisting them', async () => {

--- a/__tests__/components/settings-page.test.tsx
+++ b/__tests__/components/settings-page.test.tsx
@@ -5,6 +5,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { createRoot } from 'react-dom/client'
 import { flushSync } from 'react-dom'
 import { SettingsPage } from '@/components/SettingsPage'
+import { TrustedGithubUsersField } from '@/components/settings/TrustedGithubUsersField'
 
 const push = vi.fn()
 
@@ -20,22 +21,33 @@ function makeResponse(body: unknown, ok = true) {
   }
 }
 
-function renderSettingsPage() {
+function renderElement(element: React.ReactElement) {
   const container = document.createElement('div')
   document.body.appendChild(container)
   const root = createRoot(container)
 
-  flushSync(() => {
-    root.render(React.createElement(SettingsPage as React.ComponentType<{ initialTab?: 'pipeline' }>, { initialTab: 'pipeline' }))
-  })
+  const render = (nextElement: React.ReactElement) => {
+    flushSync(() => {
+      root.render(nextElement)
+    })
+  }
+
+  render(element)
 
   return {
     container,
+    render,
     unmount: () => {
       root.unmount()
       container.remove()
     },
   }
+}
+
+function renderSettingsPage(initialTab: 'general' | 'pipeline' = 'pipeline') {
+  return renderElement(
+    React.createElement(SettingsPage as React.ComponentType<{ initialTab?: 'general' | 'pipeline' }>, { initialTab }),
+  )
 }
 
 function findInputByLabel(container: HTMLElement, labelText: string): HTMLInputElement {
@@ -61,6 +73,46 @@ function getSaveButton(container: HTMLElement): HTMLButtonElement {
     throw new Error('Save button not found')
   }
   return button
+}
+
+function findButton(container: HTMLElement, label: string): HTMLButtonElement {
+  const button = Array.from(container.querySelectorAll('button')).find(
+    (node) => node.textContent?.trim() === label,
+  )
+  if (!(button instanceof HTMLButtonElement)) {
+    throw new Error(`Button not found: ${label}`)
+  }
+  return button
+}
+
+function findInputByValue(container: HTMLElement, value: string): HTMLInputElement {
+  const input = Array.from(container.querySelectorAll('input')).find(
+    (node) => node instanceof HTMLInputElement && node.value === value,
+  )
+  if (!(input instanceof HTMLInputElement)) {
+    throw new Error(`Input not found with value: ${value}`)
+  }
+  return input
+}
+
+function findTrustedGithubUsersSection(container: HTMLElement): HTMLElement {
+  const label = Array.from(container.querySelectorAll('label')).find(
+    (node) => node.textContent?.trim() === 'Trusted GitHub Users',
+  )
+  if (!(label instanceof HTMLLabelElement)) {
+    throw new Error('Trusted GitHub Users label not found')
+  }
+  const section = label.closest('.col-span-2')
+  if (!(section instanceof HTMLElement)) {
+    throw new Error('Trusted GitHub Users section not found')
+  }
+  return section
+}
+
+function findTrustedGithubUserInputs(container: HTMLElement): HTMLInputElement[] {
+  return Array.from(findTrustedGithubUsersSection(container).querySelectorAll('input')).filter(
+    (node): node is HTMLInputElement => node instanceof HTMLInputElement,
+  )
 }
 
 function setInputValue(input: HTMLInputElement, value: string) {
@@ -142,6 +194,178 @@ describe('SettingsPage', () => {
     )
     expect(patchCall).toBeTruthy()
     expect((patchCall?.[1] as RequestInit).body).toContain('"review_fix_max_iterations":"03"')
+
+    unmount()
+  })
+
+  it('saves and reloads trusted GitHub users through the dedicated editor', async () => {
+    const fetchMock = vi.fn(async (input: string, init?: RequestInit) => {
+      if (input === '/api/settings' && !init) {
+        return makeResponse({
+          settings: {
+            claude_provider: 'claude',
+            cli_enabled_providers: 'claude',
+            trusted_github_users: 'octocat',
+          },
+        })
+      }
+      if (input === '/api/settings' && init?.method === 'PATCH') {
+        return makeResponse({
+          status: 'ok',
+          settings: {
+            claude_provider: 'claude',
+            cli_enabled_providers: 'claude',
+            trusted_github_users: 'octocat, hubot',
+          },
+        })
+      }
+      if (input === '/api/config/projects') {
+        return makeResponse({ projects: [] })
+      }
+      throw new Error(`Unexpected fetch: ${input}`)
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    const { container, unmount } = renderSettingsPage('general')
+
+    await vi.waitFor(() => {
+      expect(findInputByValue(container, 'octocat')).toBeTruthy()
+      expect(getSaveButton(container).disabled).toBe(true)
+    })
+
+    flushSync(() => {
+      findButton(container, '+ Add user').click()
+    })
+
+    await vi.waitFor(() => {
+      expect(getSaveButton(container).disabled).toBe(true)
+      expect(container.textContent).toContain('Trusted GitHub users cannot be empty.')
+    })
+
+    window.dispatchEvent(new KeyboardEvent('keydown', { key: 's', metaKey: true, bubbles: true }))
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+
+    const emptyInput = findTrustedGithubUserInputs(container).find((node) => node.value === '')
+    if (!emptyInput) throw new Error('Empty trusted user input not found')
+
+    flushSync(() => {
+      setInputValue(emptyInput, 'hubot')
+    })
+
+    await vi.waitFor(() => {
+      expect(container.textContent).not.toContain('Trusted GitHub users cannot be empty.')
+      expect(getSaveButton(container).disabled).toBe(false)
+    })
+
+    getSaveButton(container).click()
+
+    await vi.waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith('/api/settings', expect.objectContaining({
+        method: 'PATCH',
+      }))
+    })
+
+    const patchCall = fetchMock.mock.calls.find(
+      ([input, init]) => input === '/api/settings' && (init as RequestInit | undefined)?.method === 'PATCH',
+    )
+    expect(patchCall).toBeTruthy()
+    expect((patchCall?.[1] as RequestInit).body).toContain('"trusted_github_users":"octocat, hubot"')
+
+    await vi.waitFor(() => {
+      expect(findInputByValue(container, 'octocat')).toBeTruthy()
+      expect(findInputByValue(container, 'hubot')).toBeTruthy()
+      expect(getSaveButton(container).disabled).toBe(true)
+    })
+
+    unmount()
+  })
+
+  it('blocks saving duplicate trusted GitHub users', async () => {
+    const fetchMock = vi.fn(async (input: string, init?: RequestInit) => {
+      if (input === '/api/settings' && !init) {
+        return makeResponse({
+          settings: {
+            claude_provider: 'claude',
+            cli_enabled_providers: 'claude',
+            trusted_github_users: 'octocat, hubot',
+          },
+        })
+      }
+      if (input === '/api/config/projects') {
+        return makeResponse({ projects: [] })
+      }
+      throw new Error(`Unexpected fetch: ${input}`)
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    const { container, unmount } = renderSettingsPage('general')
+
+    await vi.waitFor(() => {
+      expect(findInputByValue(container, 'octocat')).toBeTruthy()
+      expect(findInputByValue(container, 'hubot')).toBeTruthy()
+    })
+
+    const secondInput = findTrustedGithubUserInputs(container).find((node) => node.value === 'hubot')
+    if (!secondInput) throw new Error('Trusted GitHub user input not found: hubot')
+    flushSync(() => {
+      setInputValue(secondInput, 'OctoCat')
+    })
+
+    await vi.waitFor(() => {
+      expect(container.textContent).toContain('Duplicate GitHub login: OctoCat')
+      expect(getSaveButton(container).disabled).toBe(true)
+    })
+
+    window.dispatchEvent(new KeyboardEvent('keydown', { key: 's', metaKey: true, bubbles: true }))
+
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    unmount()
+  })
+
+  it('does not echo parent-provided trusted GitHub users back through onChange', async () => {
+    const onChange = vi.fn()
+    const onValidityChange = vi.fn()
+
+    const { container, render, unmount } = renderElement(
+      <TrustedGithubUsersField
+        value=""
+        onChange={onChange}
+        onValidityChange={onValidityChange}
+      />,
+    )
+
+    await vi.waitFor(() => {
+      expect(container.textContent).toContain('No trusted GitHub logins configured.')
+    })
+
+    onChange.mockClear()
+    onValidityChange.mockClear()
+
+    render(
+      <TrustedGithubUsersField
+        value="octocat"
+        onChange={onChange}
+        onValidityChange={onValidityChange}
+      />,
+    )
+
+    await vi.waitFor(() => {
+      expect(findInputByValue(container, 'octocat')).toBeTruthy()
+    })
+    expect(onChange).not.toHaveBeenCalled()
+
+    render(
+      <TrustedGithubUsersField
+        value="octocat, hubot"
+        onChange={onChange}
+        onValidityChange={onValidityChange}
+      />,
+    )
+
+    await vi.waitFor(() => {
+      expect(findInputByValue(container, 'hubot')).toBeTruthy()
+    })
+    expect(onChange).not.toHaveBeenCalled()
 
     unmount()
   })

--- a/app/api/settings/route.ts
+++ b/app/api/settings/route.ts
@@ -17,6 +17,10 @@ import {
   isCliProvider,
   parseEnabledProviders,
 } from '@/lib/usage/cli-providers';
+import {
+  canonicalizeTrustedGithubUsers,
+  validateTrustedGithubUsersInput,
+} from '@/lib/shared/trusted-github-users';
 
 function firstEnabledProvider(value: string | null | undefined): string {
   const enabled = parseEnabledProviders(value);
@@ -120,13 +124,9 @@ const SETTING_KEYS = [
 
 function serializeSettingValue(key: string, value: unknown): string {
   if (key === 'trusted_github_users') {
-    if (Array.isArray(value)) return value.join(', ');
-    try {
-      const parsed = JSON.parse(String(value));
-      return Array.isArray(parsed) ? parsed.filter((item): item is string => typeof item === 'string').join(', ') : '';
-    } catch {
-      return '';
-    }
+    if (Array.isArray(value)) return canonicalizeTrustedGithubUsers(value).join(', ');
+    try { return canonicalizeTrustedGithubUsers(JSON.parse(String(value))).join(', '); } catch {}
+    return canonicalizeTrustedGithubUsers(String(value)).join(', ');
   }
   if (key === 'github_board_status_option_ids' || key === 'github_board_custom_field_ids') {
     if (typeof value === 'string') return value;
@@ -180,6 +180,10 @@ function validateAndSerializeSettingValue(
   key: (typeof SETTING_KEYS)[number],
   value: unknown
 ): { value: string | null; error: string | null } {
+  if (key === 'trusted_github_users' && typeof value === 'string' && value.trim() === '') {
+    return { value: null, error: null };
+  }
+
   if (value === null || value === '') {
     return { value: null, error: null };
   }
@@ -206,10 +210,9 @@ function validateAndSerializeSettingValue(
   }
 
   if (key === 'trusted_github_users') {
-    const users = String(value)
-      .split(/[,\n]/)
-      .map((item) => item.trim())
-      .filter(Boolean);
+    const error = validateTrustedGithubUsersInput(value);
+    if (error) return { value: null, error };
+    const users = canonicalizeTrustedGithubUsers(value);
     return { value: JSON.stringify(users), error: null };
   }
 

--- a/components/SettingsPage.tsx
+++ b/components/SettingsPage.tsx
@@ -12,6 +12,7 @@ import { NotificationsTab } from '@/components/settings/NotificationsTab'
 import type { NotificationsSettings } from '@/components/settings/NotificationsTab'
 import { CliTab } from '@/components/settings/CliTab'
 import type { CliTabSettings } from '@/components/settings/CliTab'
+import { TrustedGithubUsersField } from '@/components/settings/TrustedGithubUsersField'
 import { parseEnabledProviders } from '@/lib/usage/cli-providers'
 
 interface SettingsMap {
@@ -140,6 +141,7 @@ export function SettingsPage({ initialTab }: { initialTab?: TabId } = {}) {
   const [saving, setSaving]               = useState(false)
   const [saved, setSaved]                 = useState(false)
   const [error, setError]                 = useState<string | null>(null)
+  const [trustedGithubUsersError, setTrustedGithubUsersError] = useState<string | null>(null)
   const [showAdvanced, setShowAdvanced]   = useState(false)
   const activeTab: TabId = initialTab && TABS.some(t => t.id === initialTab) ? initialTab : 'general'
   const switchTab = (id: TabId) => {
@@ -154,6 +156,7 @@ export function SettingsPage({ initialTab }: { initialTab?: TabId } = {}) {
   const [boardResyncMsg, setBoardResyncMsg]   = useState<string | null>(null)
 
   const isDirty = JSON.stringify(settings) !== JSON.stringify(savedSettings)
+  const canSave = isDirty && !saving && !trustedGithubUsersError
 
   useEffect(() => {
     fetch('/api/settings')
@@ -186,7 +189,7 @@ export function SettingsPage({ initialTab }: { initialTab?: TabId } = {}) {
   }, [loading, settings.workspace_path, loadProjects])
 
   const handleSave = useCallback(async () => {
-    if (saving) return
+    if (saving || trustedGithubUsersError) return
     setSaving(true)
     setSaved(false)
     setError(null)
@@ -212,18 +215,18 @@ export function SettingsPage({ initialTab }: { initialTab?: TabId } = {}) {
     } finally {
       setSaving(false)
     }
-  }, [saving, settings, loadProjects])
+  }, [saving, settings, loadProjects, trustedGithubUsersError])
 
   useEffect(() => {
     const handler = (e: KeyboardEvent) => {
       if ((e.metaKey || e.ctrlKey) && e.key === 's') {
         e.preventDefault()
-        if (isDirty) handleSave()
+        if (canSave) handleSave()
       }
     }
     window.addEventListener('keydown', handler)
     return () => window.removeEventListener('keydown', handler)
-  }, [isDirty, handleSave])
+  }, [canSave, handleSave])
 
   const handleChange = (key: keyof SettingsMap, value: string) => {
     setSettings((prev) => {
@@ -303,10 +306,10 @@ export function SettingsPage({ initialTab }: { initialTab?: TabId } = {}) {
           )}
           <button
             onClick={handleSave}
-            disabled={saving || !isDirty}
+            disabled={!canSave}
             className={`px-4 py-2 text-white border-none rounded-lg font-semibold text-sm transition-colors inline-flex items-center gap-1.5 ${
               saved      ? 'bg-status-success cursor-default' :
-              isDirty    ? 'bg-accent hover:bg-accent-hover cursor-pointer' :
+              canSave ? 'bg-accent hover:bg-accent-hover cursor-pointer' :
                            'bg-accent/40 cursor-default'
             } ${saving ? 'opacity-70 cursor-wait' : ''}`}
           >
@@ -362,6 +365,7 @@ export function SettingsPage({ initialTab }: { initialTab?: TabId } = {}) {
             const allGroupFields = (Object.keys(FIELDS) as SettingsFieldKey[]).filter(
               (k) => FIELDS[k].group === group.id
             ).filter((k) => {
+              if (k === 'trusted_github_users') return false
               // LM Studio replaces the semantic fast/normal/smart selector with
               // its own model identifier field — show one or the other, never both.
               if (k === 'lmstudio_model') return settings.claude_provider === 'lmstudio'
@@ -384,6 +388,16 @@ export function SettingsPage({ initialTab }: { initialTab?: TabId } = {}) {
                       <SettingsField key={key} fieldKey={key} value={settings[key]} provider={settings.claude_provider} onChange={handleChange} />
                     ))}
                   </div>
+
+                  {group.id === 'general' && (
+                    <div className="mt-4">
+                      <TrustedGithubUsersField
+                        value={settings.trusted_github_users}
+                        onChange={(value) => handleChange('trusted_github_users', value)}
+                        onValidityChange={setTrustedGithubUsersError}
+                      />
+                    </div>
+                  )}
 
                   {group.id === 'general' && (
                     <div className="mt-6 rounded-xl border border-border bg-bg-primary/50 p-4">

--- a/components/settings/SettingsField.tsx
+++ b/components/settings/SettingsField.tsx
@@ -27,7 +27,7 @@ export function SettingsField({
   return (
     <div className={colSpanClass}>
       <label className="block font-medium text-sm text-text-primary mb-1.5">{field.label}</label>
-      {fieldKey === 'base_prompt' || fieldKey === 'commit_style' || fieldKey === 'review_verdict_rules' || fieldKey === 'trusted_github_users' ? (
+      {fieldKey === 'base_prompt' || fieldKey === 'commit_style' || fieldKey === 'review_verdict_rules' ? (
         <textarea
           value={value}
           onChange={(e) => onChange(fieldKey, e.target.value)}

--- a/components/settings/TrustedGithubUsersField.tsx
+++ b/components/settings/TrustedGithubUsersField.tsx
@@ -1,0 +1,101 @@
+'use client'
+
+import { useEffect, useId, useState } from 'react'
+import { INPUT_CLASS } from '@/components/settings/constants'
+import {
+  parseTrustedGithubUsers,
+  serializeTrustedGithubUsers,
+  validateTrustedGithubUsersEntries,
+} from '@/lib/shared/trusted-github-users'
+
+export function TrustedGithubUsersField({
+  value,
+  onChange,
+  onValidityChange,
+}: {
+  value: string
+  onChange: (value: string) => void
+  onValidityChange: (error: string | null) => void
+}) {
+  const fieldId = useId()
+  const [users, setUsers] = useState<string[]>(() => parseTrustedGithubUsers(value))
+  const validationError = validateTrustedGithubUsersEntries(users)
+
+  function updateUsers(nextUsers: string[]) {
+    setUsers(nextUsers)
+
+    const nextError = validateTrustedGithubUsersEntries(nextUsers)
+    if (nextError) return
+
+    const nextValue = serializeTrustedGithubUsers(nextUsers)
+    if (nextValue !== value) onChange(nextValue)
+  }
+
+  useEffect(() => {
+    setUsers(parseTrustedGithubUsers(value))
+  }, [value])
+
+  useEffect(() => {
+    onValidityChange(validationError)
+  }, [onValidityChange, validationError])
+
+  return (
+    <div className="col-span-2">
+      <div className="mb-1.5 flex items-center justify-between gap-3">
+        <label htmlFor={`${fieldId}-0`} className="block font-medium text-sm text-text-primary">
+          Trusted GitHub Users
+        </label>
+        <button
+          type="button"
+          onClick={() => updateUsers([...users, ''])}
+          className="rounded-lg border border-border bg-bg-primary px-2.5 py-1 text-xs font-medium text-text-secondary transition-colors hover:bg-bg-tertiary hover:text-text-primary"
+        >
+          + Add user
+        </button>
+      </div>
+
+      <div className="rounded-lg border border-border bg-bg-primary/60 p-3">
+        {users.length === 0 ? (
+          <p className="text-sm text-text-secondary">No trusted GitHub logins configured.</p>
+        ) : (
+          <div className="space-y-2">
+            {users.map((user, index) => (
+              <div key={index} className="flex items-center gap-2">
+                <input
+                  id={`${fieldId}-${index}`}
+                  type="text"
+                  value={user}
+                  onChange={(event) => {
+                    const nextUsers = users.slice()
+                    nextUsers[index] = event.target.value
+                    updateUsers(nextUsers)
+                  }}
+                  placeholder="octocat"
+                  className={INPUT_CLASS}
+                  autoCapitalize="none"
+                  autoCorrect="off"
+                  spellCheck={false}
+                />
+                <button
+                  type="button"
+                  onClick={() => updateUsers(users.filter((_, itemIndex) => itemIndex !== index))}
+                  className="rounded-lg border border-border bg-bg-primary px-2.5 py-2 text-xs font-medium text-text-secondary transition-colors hover:bg-bg-tertiary hover:text-text-primary"
+                  aria-label={`Remove trusted GitHub user ${user || index + 1}`}
+                >
+                  Remove
+                </button>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+
+      <p className="mt-1.5 text-xs text-text-tertiary">
+        Global allowlist for issue and PR authors whose GitHub content TamTam may treat as trusted. Unioned with each project&apos;s <code className="font-mono">.tamtam/config.yml</code> <code className="font-mono">security.safe_users</code>.
+      </p>
+      {validationError && (
+        <p className="mt-2 text-xs text-status-error">{validationError}</p>
+      )}
+    </div>
+  )
+}

--- a/components/settings/constants.ts
+++ b/components/settings/constants.ts
@@ -23,7 +23,7 @@ export const FIELDS: Record<SettingsFieldKey, FieldDef> = {
   },
   trusted_github_users: {
     label: 'Trusted GitHub Users',
-    help: 'Comma-separated global allowlist for issue/PR authors whose GitHub content TamTam may treat as trusted. Unioned with each project’s `.tamtam/config.yml` `security.safe_users`.',
+    help: 'Global allowlist for issue/PR authors whose GitHub content TamTam may treat as trusted. Managed through the dedicated editor in Settings → General.',
     group: 'general',
     span: 2,
   },

--- a/docs/API.md
+++ b/docs/API.md
@@ -78,7 +78,7 @@ Complete reference for TamTam HTTP API routes. All routes live under `app/api/`.
 
 ## Settings
 
-- `/api/settings` — Settings CRUD (GET, PATCH) — includes GitHub board sync, CLI routing/binary/model, `base_prompt`, permission mode, pipeline model overrides, budget gates, retention, and all `notification_*` keys
+- `/api/settings` — Settings CRUD (GET, PATCH) — includes GitHub board sync, CLI routing/binary/model, `base_prompt`, permission mode, the dedicated global trusted-GitHub-users allowlist (`trusted_github_users`), pipeline model overrides, budget gates, retention, and all `notification_*` keys. `trusted_github_users` is stored as JSON in the DB but exposed by this route as a comma-separated string for the Settings UI.
 - `/api/settings/test-notification` — Send a test webhook payload (POST)
 - `/api/settings/board-resync` — Re-run `syncJobToProjectBoard(job, 'manual')` for the most recent release/agent/run jobs (default last 7d, top 100; `?days=`/`?limit=`); skips pipeline child jobs, stops on GitHub secondary rate-limit, 250 ms inter-call delay (POST → `{ ok, days, limit, scanned, resynced, failed, rateLimited }`)
 - `/api/settings/backup` — SQLite hot backup (POST)

--- a/docs/SETTINGS.md
+++ b/docs/SETTINGS.md
@@ -20,7 +20,7 @@ All settings stored in the `settings` table (key-value, both TEXT). Accessed via
 |-----|------|---------|--------|
 | `workspace_path` | string | `''` | Root directory scanned for git repos; drives the projects list |
 | `github_owner` | string | `''` | Default GitHub org/user for repos without an explicit remote URL |
-| `trusted_github_users` | JSON string array | `[]` | Global GitHub-login allowlist for trusted external issue/PR authors. Stored as JSON in `settings`, unioned with each project’s `.tamtam/config.yml` `security.safe_users`, and used by untrusted-content wrapping plus trusted-only issue selection |
+| `trusted_github_users` | JSON string array | `[]` | Global GitHub-login allowlist for trusted external issue/PR authors. Managed in Settings → General via the dedicated Trusted GitHub Users editor, stored as JSON in `settings`, unioned with each project’s `.tamtam/config.yml` `security.safe_users`, and used by untrusted-content wrapping plus trusted-only issue selection |
 | `github_board_sync_enabled` | boolean | `false` | Stored as `'true'`/`'false'`. Enables GitHub Project sync for run/release lifecycle updates |
 | `github_board_project_owner` | string | `''` | GitHub org/user that owns the shared TamTam project board. Falls back to `github_owner` when blank |
 | `github_board_project_title` | string | `'TamTam'` | Project board title TamTam creates or reuses when sync is enabled |

--- a/lib/shared/trusted-github-users.ts
+++ b/lib/shared/trusted-github-users.ts
@@ -1,0 +1,53 @@
+function toEntries(value: unknown): string[] {
+  if (Array.isArray(value)) {
+    return value.filter((item): item is string => typeof item === 'string');
+  }
+  return String(value).split(/[,\n]/);
+}
+
+export function parseTrustedGithubUsers(value: string): string[] {
+  return canonicalizeTrustedGithubUsers(value);
+}
+
+export function serializeTrustedGithubUsers(users: string[]): string {
+  return users.map((user) => user.trim()).filter(Boolean).join(', ');
+}
+
+export function canonicalizeTrustedGithubUsers(value: unknown): string[] {
+  const seen = new Set<string>();
+  const users: string[] = [];
+
+  for (const entry of toEntries(value)) {
+    const trimmed = entry.trim();
+    if (!trimmed) continue;
+    const normalized = trimmed.toLowerCase();
+    if (seen.has(normalized)) continue;
+    seen.add(normalized);
+    users.push(trimmed);
+  }
+
+  return users;
+}
+
+export function validateTrustedGithubUsersEntries(users: string[]): string | null {
+  const seen = new Set<string>();
+
+  for (const user of users) {
+    const trimmed = user.trim();
+    if (!trimmed) return 'Trusted GitHub users cannot be empty.';
+
+    const normalized = trimmed.toLowerCase();
+    if (seen.has(normalized)) return `Duplicate GitHub login: ${trimmed}`;
+    seen.add(normalized);
+  }
+
+  return null;
+}
+
+export function validateTrustedGithubUsersInput(value: unknown): string | null {
+  const entries = toEntries(value);
+  const hasMeaningfulEntry = entries.some((entry) => entry.trim().length > 0);
+  if (!hasMeaningfulEntry) return null;
+
+  return validateTrustedGithubUsersEntries(entries);
+}


### PR DESCRIPTION
Closes #114

Implemented via TamTam from issue [#114](https://github.com/3h4x/tamtam/issues/114).