### PR TITLE
fix: Throttle and dedupe webhook notifications so a flapping agent doesn't spam Slack/Discord

### DIFF
--- a/__tests__/api/monitoring.test.ts
+++ b/__tests__/api/monitoring.test.ts
@@ -1,4 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import Database from 'better-sqlite3';
+import { drizzle } from 'drizzle-orm/better-sqlite3';
+import * as schema from '@/lib/db/schema';
 
 function makeJsonResponse(data: unknown, status = 200) {
   return Promise.resolve({
@@ -20,12 +23,37 @@ function makeRequest(url = 'http://localhost/api/monitoring') {
   return new Request(url);
 }
 
+function createTestDb() {
+  const sqlite = new Database(':memory:');
+  sqlite.pragma('journal_mode = WAL');
+  sqlite.exec(`
+    CREATE TABLE notification_throttle (
+      key TEXT PRIMARY KEY,
+      last_sent_at INTEGER NOT NULL,
+      suppressed_count INTEGER NOT NULL DEFAULT 0
+    );
+  `);
+  return { sqlite, db: drizzle(sqlite, { schema }) };
+}
+
 describe('GET /api/monitoring', () => {
   let GET: any;
   let fetchSpy: ReturnType<typeof vi.fn>;
+  let testDb: ReturnType<typeof createTestDb>;
 
   beforeEach(async () => {
     vi.resetModules();
+    testDb = createTestDb();
+    vi.doMock('@/lib/db', () => ({
+      db: testDb.db,
+      schema,
+    }));
+    vi.doMock('@/lib/shared/config', () => ({
+      getSettings: () => ({
+        notification_throttle_window_seconds: 900,
+        notification_throttle_overrides: { release_fail: 0, release_aborted: 0 },
+      }),
+    }));
     fetchSpy = vi.fn();
     vi.stubGlobal('fetch', fetchSpy);
     const mod = await import('@/app/api/monitoring/route');
@@ -47,6 +75,12 @@ describe('GET /api/monitoring', () => {
     expect(data.loki.status).toBe('unavailable');
     expect(data.hasIssues).toBe(false);
     expect(typeof data.fetchedAt).toBe('number');
+    expect(data.notificationThrottle).toEqual({
+      windowSeconds: 900,
+      overrides: { release_fail: 0, release_aborted: 0 },
+      suppressedTotal: 0,
+      entries: [],
+    });
   });
 
   it('returns ok with no issues when all services up and no alerts', async () => {
@@ -200,6 +234,38 @@ describe('GET /api/monitoring', () => {
     const data = await res.json();
     expect(data.windowMs).toBe(60 * 60 * 1000);
     expect(typeof data.fetchedAt).toBe('number');
+  });
+
+  it('includes notification throttle rows ordered by suppressed count', async () => {
+    testDb.sqlite.prepare('INSERT INTO notification_throttle (key, last_sent_at, suppressed_count) VALUES (?, ?, ?)').run('agent_run_fail:p:qa', 1000, 2);
+    testDb.sqlite.prepare('INSERT INTO notification_throttle (key, last_sent_at, suppressed_count) VALUES (?, ?, ?)').run('review_do_not_ship:p:review', 2000, 5);
+    testDb.sqlite.prepare('INSERT INTO notification_throttle (key, last_sent_at, suppressed_count) VALUES (?, ?, ?)').run('release_success:p:release', 3000, 0);
+    fetchSpy.mockRejectedValue(new Error('connection refused'));
+
+    const res = await GET(makeRequest());
+    const data = await res.json();
+
+    expect(data.notificationThrottle.suppressedTotal).toBe(7);
+    expect(data.notificationThrottle.entries.map((entry: { key: string }) => entry.key)).toEqual([
+      'review_do_not_ship:p:review',
+      'agent_run_fail:p:qa',
+    ]);
+  });
+
+  it('reports suppressedTotal across all rows while limiting entries to the top 20', async () => {
+    const insert = testDb.sqlite.prepare('INSERT INTO notification_throttle (key, last_sent_at, suppressed_count) VALUES (?, ?, ?)');
+    for (let i = 1; i <= 25; i += 1) {
+      insert.run(`agent_run_fail:p:agent-${i}`, i * 1000, i);
+    }
+    fetchSpy.mockRejectedValue(new Error('connection refused'));
+
+    const res = await GET(makeRequest());
+    const data = await res.json();
+
+    expect(data.notificationThrottle.suppressedTotal).toBe(325);
+    expect(data.notificationThrottle.entries).toHaveLength(20);
+    expect(data.notificationThrottle.entries[0].key).toBe('agent_run_fail:p:agent-25');
+    expect(data.notificationThrottle.entries[19].key).toBe('agent_run_fail:p:agent-6');
   });
 
   it('loki queries exclude info/debug/trace log levels', async () => {

--- a/__tests__/components/notifications-tab.test.tsx
+++ b/__tests__/components/notifications-tab.test.tsx
@@ -24,6 +24,8 @@ function baseSettings(): NotificationsSettings {
     notification_on_review_do_not_ship: 'false',
     notification_on_agent_run_fail: 'false',
     notification_on_budget_blocked: 'false',
+    notification_throttle_window_seconds: '900',
+    notification_throttle_overrides: '{"release_fail":0,"release_aborted":0}',
   }
 }
 

--- a/__tests__/lib/cli-bin.test.ts
+++ b/__tests__/lib/cli-bin.test.ts
@@ -52,6 +52,8 @@ function makeSettings(overrides: Partial<TamTamConfig> = {}): TamTamConfig {
     notification_on_fix_loop_exhausted: false,
     notification_on_review_do_not_ship: false,
     notification_on_agent_run_fail: false,
+    notification_throttle_window_seconds: 900,
+    notification_throttle_overrides: { release_fail: 0, release_aborted: 0 },
     pipeline_model_review: '',
     pipeline_model_fix: '',
     pipeline_model_dod: '',

--- a/__tests__/lib/config.test.ts
+++ b/__tests__/lib/config.test.ts
@@ -105,6 +105,8 @@ describe('config', () => {
         notification_on_review_do_not_ship: false,
         notification_on_agent_run_fail: false,
         notification_on_budget_blocked: false,
+        notification_throttle_window_seconds: 900,
+        notification_throttle_overrides: { release_fail: 0, release_aborted: 0 },
         budget_block_runs_enabled: false,
         budget_subscription_providers: ['claude', 'codex'],
         budget_block_at_pct: 95,

--- a/__tests__/lib/job-control.test.ts
+++ b/__tests__/lib/job-control.test.ts
@@ -265,7 +265,10 @@ describe('job-control', () => {
       // notify is fire-and-forget; wait a microtask
       await new Promise<void>((r) => setTimeout(r, 0));
       expect(notifyMock).toHaveBeenCalledWith(
-        expect.objectContaining({ event: 'budget_blocked' })
+        expect.objectContaining({
+          event: 'budget_blocked',
+          throttleKeySuffix: 'budget:5h:2099-01-01T00:00:00Z',
+        })
       );
     });
 
@@ -275,6 +278,24 @@ describe('job-control', () => {
       budgetBlockedResult();
       await new Promise<void>((r) => setTimeout(r, 0));
       expect(notifyMock).toHaveBeenCalledTimes(1);
+    });
+
+    it('notifies again when the reset window identity changes', async () => {
+      peekQuotaCacheMock
+        .mockReturnValueOnce(makeSnapshot(96, 40, '2099-01-01T00:00:00Z'))
+        .mockReturnValueOnce(makeSnapshot(96, 40, '2099-01-01T01:00:00Z'));
+      budgetBlockedResult();
+      budgetBlockedResult();
+      await new Promise<void>((r) => setTimeout(r, 0));
+      expect(notifyMock).toHaveBeenCalledTimes(2);
+      expect(notifyMock).toHaveBeenNthCalledWith(
+        1,
+        expect.objectContaining({ throttleKeySuffix: 'budget:5h:2099-01-01T00:00:00Z' })
+      );
+      expect(notifyMock).toHaveBeenNthCalledWith(
+        2,
+        expect.objectContaining({ throttleKeySuffix: 'budget:5h:2099-01-01T01:00:00Z' })
+      );
     });
   });
 

--- a/__tests__/lib/notifications.test.ts
+++ b/__tests__/lib/notifications.test.ts
@@ -1,4 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import Database from 'better-sqlite3';
+import { drizzle } from 'drizzle-orm/better-sqlite3';
+import * as schema from '@/lib/db/schema';
 
 type Settings = {
   notification_webhook_url: string;
@@ -8,6 +11,10 @@ type Settings = {
   notification_on_fix_loop_exhausted: boolean;
   notification_on_review_do_not_ship: boolean;
   notification_on_agent_run_fail: boolean;
+  notification_on_release_aborted: boolean;
+  notification_on_budget_blocked: boolean;
+  notification_throttle_window_seconds: number;
+  notification_throttle_overrides: Record<string, number>;
 };
 
 function defaultSettings(overrides: Partial<Settings> = {}): Settings {
@@ -19,8 +26,25 @@ function defaultSettings(overrides: Partial<Settings> = {}): Settings {
     notification_on_fix_loop_exhausted: false,
     notification_on_review_do_not_ship: false,
     notification_on_agent_run_fail: false,
+    notification_on_release_aborted: false,
+    notification_on_budget_blocked: false,
+    notification_throttle_window_seconds: 900,
+    notification_throttle_overrides: { release_fail: 0, release_aborted: 0 },
     ...overrides,
   };
+}
+
+function createTestDb() {
+  const sqlite = new Database(':memory:');
+  sqlite.pragma('journal_mode = WAL');
+  sqlite.exec(`
+    CREATE TABLE notification_throttle (
+      key TEXT PRIMARY KEY,
+      last_sent_at INTEGER NOT NULL,
+      suppressed_count INTEGER NOT NULL DEFAULT 0
+    );
+  `);
+  return { sqlite, db: drizzle(sqlite, { schema }) };
 }
 
 const SLACK_URL = 'https://hooks.slack.com/services/T000/B000/xxx';
@@ -30,11 +54,17 @@ const GENERIC_URL = 'https://ntfy.sh/my-topic';
 describe('lib/notifications', () => {
   let mockGetSettings: ReturnType<typeof vi.fn>;
   let mockFetch: ReturnType<typeof vi.fn>;
+  let testDb: ReturnType<typeof createTestDb>;
 
   beforeEach(async () => {
     vi.resetModules();
+    testDb = createTestDb();
     mockGetSettings = vi.fn().mockReturnValue(defaultSettings());
     vi.doMock('@/lib/shared/config', () => ({ getSettings: mockGetSettings }));
+    vi.doMock('@/lib/db', () => ({
+      db: testDb.db,
+      schema,
+    }));
     mockFetch = vi.fn().mockResolvedValue({ ok: true });
     vi.stubGlobal('fetch', mockFetch);
   });
@@ -44,9 +74,11 @@ describe('lib/notifications', () => {
     vi.resetModules();
   });
 
-  // Helper to flush the microtask / promise queue so fire-and-forget calls land
+  // Helper to flush the microtask / promise queue so fire-and-forget calls land.
   async function flush() {
-    await new Promise<void>((r) => setTimeout(r, 10));
+    for (let i = 0; i < 10; i += 1) {
+      await Promise.resolve();
+    }
   }
 
   describe('notify()', () => {
@@ -168,6 +200,261 @@ describe('lib/notifications', () => {
       const body = JSON.parse(opts.body);
       expect(body.timestamp).toBeGreaterThanOrEqual(before);
     });
+
+    it('suppresses duplicate agent failures with the same key inside the throttle window', async () => {
+      mockGetSettings.mockReturnValue(
+        defaultSettings({
+          notification_webhook_url: GENERIC_URL,
+          notification_on_agent_run_fail: true,
+          notification_throttle_window_seconds: 900,
+        }),
+      );
+      const { notify } = await import('@/lib/shared/notifications');
+
+      await notify({ event: 'agent_run_fail', project: 'p', agent: 'qa', job_id: 'j1', status: 'failed', timestamp: 1000 });
+      await notify({ event: 'agent_run_fail', project: 'p', agent: 'qa', job_id: 'j2', status: 'failed', timestamp: 2000 });
+      await flush();
+
+      expect(mockFetch).toHaveBeenCalledOnce();
+      const row = testDb.sqlite
+        .prepare('SELECT * FROM notification_throttle WHERE key = ?')
+        .get('agent_run_fail:p:qa') as { suppressed_count: number } | undefined;
+      expect(row?.suppressed_count).toBe(1);
+    });
+
+    it('always sends release_fail when the default override disables throttling', async () => {
+      mockGetSettings.mockReturnValue(
+        defaultSettings({
+          notification_webhook_url: GENERIC_URL,
+          notification_on_release_fail: true,
+        }),
+      );
+      const { notify } = await import('@/lib/shared/notifications');
+
+      await notify({ event: 'release_fail', project: 'p', job_id: 'j1', status: 'failed', timestamp: 1000 });
+      await notify({ event: 'release_fail', project: 'p', job_id: 'j2', status: 'failed', timestamp: 2000 });
+      await flush();
+
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+    });
+
+    it('does not leak throttleKeySuffix in generic webhook payloads', async () => {
+      mockGetSettings.mockReturnValue(
+        defaultSettings({
+          notification_webhook_url: GENERIC_URL,
+          notification_on_budget_blocked: true,
+        }),
+      );
+      const { notify } = await import('@/lib/shared/notifications');
+
+      await notify({
+        event: 'budget_blocked',
+        project: 'tamtam',
+        job_id: '-',
+        status: 'failed',
+        message: 'quota blocked',
+        throttleKeySuffix: 'budget:5h:2099-01-01T00:00:00Z',
+        timestamp: 1000,
+      });
+      await flush();
+
+      const [, opts] = mockFetch.mock.calls[0];
+      const body = JSON.parse(opts.body);
+      expect(body.throttleKeySuffix).toBeUndefined();
+      expect(body.event).toBe('budget_blocked');
+    });
+
+    it('sends budget-blocked alerts for different throttle identities inside the same window', async () => {
+      mockGetSettings.mockReturnValue(
+        defaultSettings({
+          notification_webhook_url: GENERIC_URL,
+          notification_on_budget_blocked: true,
+        }),
+      );
+      const { notify } = await import('@/lib/shared/notifications');
+
+      await notify({
+        event: 'budget_blocked',
+        project: 'tamtam',
+        job_id: '-',
+        status: 'failed',
+        message: 'first window',
+        throttleKeySuffix: 'budget:5h:2099-01-01T00:00:00Z',
+        timestamp: 1000,
+      });
+      await notify({
+        event: 'budget_blocked',
+        project: 'tamtam',
+        job_id: '-',
+        status: 'failed',
+        message: 'second window',
+        throttleKeySuffix: 'budget:5h:2099-01-01T01:00:00Z',
+        timestamp: 2000,
+      });
+      await flush();
+
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+      const rows = testDb.sqlite
+        .prepare('SELECT key FROM notification_throttle ORDER BY key')
+        .all() as Array<{ key: string }>;
+      expect(rows.map((row) => row.key)).toEqual([
+        'budget_blocked:tamtam:budget:5h:2099-01-01T00:00:00Z',
+        'budget_blocked:tamtam:budget:5h:2099-01-01T01:00:00Z',
+      ]);
+    });
+
+    it('still suppresses budget-blocked repeats for the same throttle identity', async () => {
+      mockGetSettings.mockReturnValue(
+        defaultSettings({
+          notification_webhook_url: GENERIC_URL,
+          notification_on_budget_blocked: true,
+        }),
+      );
+      const { notify } = await import('@/lib/shared/notifications');
+
+      await notify({
+        event: 'budget_blocked',
+        project: 'tamtam',
+        job_id: '-',
+        status: 'failed',
+        message: 'same window',
+        throttleKeySuffix: 'budget:5h:2099-01-01T00:00:00Z',
+        timestamp: 1000,
+      });
+      await notify({
+        event: 'budget_blocked',
+        project: 'tamtam',
+        job_id: '-',
+        status: 'failed',
+        message: 'same window retry',
+        throttleKeySuffix: 'budget:5h:2099-01-01T00:00:00Z',
+        timestamp: 2000,
+      });
+      await flush();
+
+      expect(mockFetch).toHaveBeenCalledOnce();
+      const row = testDb.sqlite
+        .prepare('SELECT * FROM notification_throttle WHERE key = ?')
+        .get('budget_blocked:tamtam:budget:5h:2099-01-01T00:00:00Z') as { suppressed_count: number } | undefined;
+      expect(row?.suppressed_count).toBe(1);
+    });
+
+    it('includes suppressedSince when sending after the throttle window expires', async () => {
+      mockGetSettings.mockReturnValue(
+        defaultSettings({
+          notification_webhook_url: GENERIC_URL,
+          notification_on_agent_run_fail: true,
+          notification_throttle_window_seconds: 10,
+        }),
+      );
+      const { notify } = await import('@/lib/shared/notifications');
+
+      await notify({ event: 'agent_run_fail', project: 'p', agent: 'qa', job_id: 'j1', status: 'failed', timestamp: 1000 });
+      await notify({ event: 'agent_run_fail', project: 'p', agent: 'qa', job_id: 'j2', status: 'failed', timestamp: 2000 });
+      await notify({ event: 'agent_run_fail', project: 'p', agent: 'qa', job_id: 'j3', status: 'failed', timestamp: 12_000 });
+      await new Promise<void>((resolve) => setTimeout(resolve, 0));
+      await flush();
+
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+      const [, opts] = mockFetch.mock.calls[1];
+      const body = JSON.parse(opts.body);
+      expect(body.suppressedSince).toBe(1);
+      expect(body.message).toContain('1 more notification suppressed since the last alert.');
+    });
+
+    it('does not create a throttle row when the first throttled delivery fails', async () => {
+      vi.useFakeTimers();
+      mockFetch.mockRejectedValue(new Error('network down'));
+      mockGetSettings.mockReturnValue(
+        defaultSettings({
+          notification_webhook_url: GENERIC_URL,
+          notification_on_release_success: true,
+        }),
+      );
+      const { notify } = await import('@/lib/shared/notifications');
+
+      await notify({ event: 'release_success', project: 'p', job_id: 'j1', status: 'success', timestamp: 1000 });
+      await vi.runAllTimersAsync();
+      await flush();
+
+      expect(mockFetch).toHaveBeenCalledTimes(3);
+      const row = testDb.sqlite
+        .prepare('SELECT * FROM notification_throttle WHERE key = ?')
+        .get('release_success:p:release');
+      expect(row).toBeUndefined();
+      vi.useRealTimers();
+    });
+
+    it('keeps the last delivered throttle state when a resend after the window fails', async () => {
+      vi.useFakeTimers();
+      mockGetSettings.mockReturnValue(
+        defaultSettings({
+          notification_webhook_url: GENERIC_URL,
+          notification_on_agent_run_fail: true,
+          notification_throttle_window_seconds: 10,
+        }),
+      );
+      const { notify } = await import('@/lib/shared/notifications');
+
+      await notify({ event: 'agent_run_fail', project: 'p', agent: 'qa', job_id: 'j1', status: 'failed', timestamp: 1000 });
+      await flush();
+
+      mockFetch.mockResolvedValue({ ok: true });
+      await notify({ event: 'agent_run_fail', project: 'p', agent: 'qa', job_id: 'j2', status: 'failed', timestamp: 2000 });
+      await flush();
+
+      mockFetch.mockReset();
+      mockFetch.mockRejectedValue(new Error('network down'));
+      await notify({ event: 'agent_run_fail', project: 'p', agent: 'qa', job_id: 'j3', status: 'failed', timestamp: 12_000 });
+      await vi.runAllTimersAsync();
+      await flush();
+
+      expect(mockFetch).toHaveBeenCalledTimes(3);
+      const row = testDb.sqlite
+        .prepare('SELECT * FROM notification_throttle WHERE key = ?')
+        .get('agent_run_fail:p:qa') as { last_sent_at: number; suppressed_count: number } | undefined;
+      expect(row).toMatchObject({ key: 'agent_run_fail:p:qa', last_sent_at: 1000, suppressed_count: 1 });
+      vi.useRealTimers();
+    });
+
+    it('retries with the accumulated suppressed count after a failed resend eventually succeeds', async () => {
+      vi.useFakeTimers();
+      mockGetSettings.mockReturnValue(
+        defaultSettings({
+          notification_webhook_url: GENERIC_URL,
+          notification_on_agent_run_fail: true,
+          notification_throttle_window_seconds: 10,
+        }),
+      );
+      const { notify } = await import('@/lib/shared/notifications');
+
+      await notify({ event: 'agent_run_fail', project: 'p', agent: 'qa', job_id: 'j1', status: 'failed', timestamp: 1000 });
+      await flush();
+
+      await notify({ event: 'agent_run_fail', project: 'p', agent: 'qa', job_id: 'j2', status: 'failed', timestamp: 2000 });
+      await flush();
+
+      mockFetch.mockReset();
+      mockFetch.mockRejectedValue(new Error('network down'));
+      await notify({ event: 'agent_run_fail', project: 'p', agent: 'qa', job_id: 'j3', status: 'failed', timestamp: 12_000 });
+      await vi.runAllTimersAsync();
+      await flush();
+
+      mockFetch.mockReset();
+      mockFetch.mockResolvedValue({ ok: true });
+      await notify({ event: 'agent_run_fail', project: 'p', agent: 'qa', job_id: 'j4', status: 'failed', timestamp: 13_000 });
+      await flush();
+
+      expect(mockFetch).toHaveBeenCalledOnce();
+      const [, opts] = mockFetch.mock.calls[0];
+      const body = JSON.parse(opts.body);
+      expect(body.suppressedSince).toBe(1);
+      const row = testDb.sqlite
+        .prepare('SELECT * FROM notification_throttle WHERE key = ?')
+        .get('agent_run_fail:p:qa') as { last_sent_at: number; suppressed_count: number } | undefined;
+      expect(row).toMatchObject({ key: 'agent_run_fail:p:qa', last_sent_at: 13_000, suppressed_count: 0 });
+      vi.useRealTimers();
+    });
   });
 
   describe('adapter selection (detectWebhookType)', () => {
@@ -218,6 +505,7 @@ describe('lib/notifications', () => {
           notification_webhook_url: GENERIC_URL,
           notification_webhook_secret: 'testsecret',
           notification_on_release_success: true,
+          notification_throttle_overrides: { release_success: 0, release_fail: 0, release_aborted: 0 },
         }),
       );
       const { notify } = await import('@/lib/shared/notifications');
@@ -240,7 +528,12 @@ describe('lib/notifications', () => {
       const payload = { event: 'release_success' as const, project: 'p', job_id: 'j', status: 'success' as const, timestamp: 42 };
 
       mockGetSettings.mockReturnValue(
-        defaultSettings({ notification_webhook_url: GENERIC_URL, notification_webhook_secret: 'secret1', notification_on_release_success: true }),
+        defaultSettings({
+          notification_webhook_url: GENERIC_URL,
+          notification_webhook_secret: 'secret1',
+          notification_on_release_success: true,
+          notification_throttle_overrides: { release_success: 0, release_fail: 0, release_aborted: 0 },
+        }),
       );
       await notify({ ...payload });
       await flush();
@@ -248,7 +541,12 @@ describe('lib/notifications', () => {
 
       mockFetch.mockClear();
       mockGetSettings.mockReturnValue(
-        defaultSettings({ notification_webhook_url: GENERIC_URL, notification_webhook_secret: 'secret2', notification_on_release_success: true }),
+        defaultSettings({
+          notification_webhook_url: GENERIC_URL,
+          notification_webhook_secret: 'secret2',
+          notification_on_release_success: true,
+          notification_throttle_overrides: { release_success: 0, release_fail: 0, release_aborted: 0 },
+        }),
       );
       await notify({ ...payload });
       await flush();

--- a/app/api/monitoring/route.ts
+++ b/app/api/monitoring/route.ts
@@ -1,4 +1,6 @@
 import { NextResponse } from 'next/server'
+import { db, schema } from '@/lib/db'
+import { getSettings } from '@/lib/shared/config'
 
 const PROMETHEUS_URL = process.env.PROMETHEUS_URL ?? 'http://localhost:9090'
 const LOKI_URL = process.env.LOKI_URL ?? 'http://localhost:3100'
@@ -95,9 +97,24 @@ export async function GET(request: Request) {
   ])
 
   const downServices = prometheus.services.filter(s => s.value?.[1] === '0')
+  const settings = getSettings()
+  const throttledNotifications = db.select()
+    .from(schema.notificationThrottle)
+    .all()
+  const suppressedTotal = throttledNotifications.reduce((sum, row) => sum + row.suppressedCount, 0)
+  const topThrottledNotifications = throttledNotifications
+    .filter((row) => row.suppressedCount > 0)
+    .sort((a, b) => b.suppressedCount - a.suppressedCount || b.lastSentAt - a.lastSentAt)
+    .slice(0, 20)
+  const notificationThrottle = {
+    windowSeconds: settings.notification_throttle_window_seconds,
+    overrides: settings.notification_throttle_overrides,
+    suppressedTotal,
+    entries: topThrottledNotifications,
+  }
   const hasIssues =
     (prometheus.status === 'ok' && (prometheus.alerts.length > 0 || downServices.length > 0)) ||
     (loki.status === 'ok' && loki.errors.length > 0)
 
-  return NextResponse.json({ prometheus, loki, hasIssues, fetchedAt: now, windowMs, config: { prometheusUrl: PROMETHEUS_URL, lokiUrl: LOKI_URL } })
+  return NextResponse.json({ prometheus, loki, notificationThrottle, hasIssues, fetchedAt: now, windowMs, config: { prometheusUrl: PROMETHEUS_URL, lokiUrl: LOKI_URL } })
 }

--- a/app/api/settings/route.ts
+++ b/app/api/settings/route.ts
@@ -110,6 +110,8 @@ const SETTING_KEYS = [
   'notification_on_review_do_not_ship',
   'notification_on_agent_run_fail',
   'notification_on_budget_blocked',
+  'notification_throttle_window_seconds',
+  'notification_throttle_overrides',
   'budget_block_runs_enabled',
   'budget_subscription_providers',
   'budget_block_at_pct',
@@ -219,6 +221,30 @@ function validateAndSerializeSettingValue(
 
   if (key === 'review_fix_max_iterations') {
     return parsePositiveIntegerSetting(value, 'review_fix_max_iterations');
+  }
+
+  if (key === 'notification_throttle_window_seconds') {
+    return parsePositiveIntegerSetting(value, 'notification_throttle_window_seconds');
+  }
+
+  if (key === 'notification_throttle_overrides') {
+    try {
+      const parsed = JSON.parse(String(value));
+      if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+        return { value: null, error: 'notification_throttle_overrides must be a JSON object.' };
+      }
+      const normalized: Record<string, number> = {};
+      for (const [event, seconds] of Object.entries(parsed)) {
+        const n = typeof seconds === 'number' ? seconds : Number.parseInt(String(seconds), 10);
+        if (!Number.isFinite(n) || n < 0) {
+          return { value: null, error: 'notification_throttle_overrides values must be non-negative seconds.' };
+        }
+        normalized[event] = n;
+      }
+      return { value: JSON.stringify(normalized), error: null };
+    } catch {
+      return { value: null, error: 'notification_throttle_overrides must be valid JSON.' };
+    }
   }
 
   if (key === 'trusted_github_users') {

--- a/components/SettingsPage.tsx
+++ b/components/SettingsPage.tsx
@@ -63,6 +63,8 @@ interface SettingsMap {
   notification_on_review_do_not_ship: string
   notification_on_agent_run_fail: string
   notification_on_budget_blocked: string
+  notification_throttle_window_seconds: string
+  notification_throttle_overrides: string
   budget_block_runs_enabled: string
   budget_subscription_providers: string
   budget_block_at_pct: string
@@ -94,6 +96,8 @@ const SETTINGS_DEFAULTS: SettingsMap = {
   cli_default_model_lmstudio: 'normal',
   jobs_paused: 'false',
   notification_on_budget_blocked: 'false',
+  notification_throttle_window_seconds: '900',
+  notification_throttle_overrides: '{"release_fail":0,"release_aborted":0}',
   budget_block_runs_enabled: 'false',
   budget_subscription_providers: 'claude,codex',
   budget_block_at_pct: '95',

--- a/components/monitoring/OverviewTab.tsx
+++ b/components/monitoring/OverviewTab.tsx
@@ -23,6 +23,7 @@ export function OverviewTab({
   const upServices = data.prometheus.services.filter(s => s.value?.[1] !== '0')
   const pm2ErrorCount = pm2Logs?.entries.filter(e => e.level === 'error').length ?? 0
   const pm2WarnCount  = pm2Logs?.entries.filter(e => e.level === 'warn').length ?? 0
+  const throttle = data.notificationThrottle
 
   const sections = [
     {
@@ -57,6 +58,16 @@ export function OverviewTab({
         data.loki.status !== 'unavailable' && data.loki.errors.length === 0 && data.loki.warnings.length === 0 ? 'No errors or warnings' : null,
       ].filter(Boolean) as string[],
     },
+    {
+      title: 'Notifications',
+      status: 'ok',
+      lines: [
+        `Throttle window ${throttle.windowSeconds}s`,
+        throttle.suppressedTotal > 0
+          ? `${throttle.suppressedTotal} suppressed alert${throttle.suppressedTotal === 1 ? '' : 's'} pending`
+          : 'No suppressed alerts pending',
+      ],
+    },
   ] as const
 
   const statusIcon = (s: string) =>
@@ -68,7 +79,7 @@ export function OverviewTab({
 
   return (
     <div className="space-y-4">
-      <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
+      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-3">
         {sections.map(sec => (
           <div key={sec.title} className={`rounded-lg border p-4 flex flex-col gap-2 ${statusCls(sec.status)}`}>
             <div className="flex items-center justify-between gap-2">
@@ -85,6 +96,21 @@ export function OverviewTab({
           </div>
         ))}
       </div>
+
+      {throttle.entries.length > 0 && (
+        <div>
+          <h3 className="text-xs font-medium text-text-secondary mb-2 uppercase tracking-wide">Notification throttle</h3>
+          <div className="space-y-1">
+            {throttle.entries.map((entry) => (
+              <div key={entry.key} className="flex items-center gap-2 px-3 py-2 rounded-md border border-border bg-bg-secondary text-sm">
+                <span className="font-mono text-xs text-text-primary truncate" data-private>{entry.key}</span>
+                <span className="ml-auto text-xs text-text-tertiary">{entry.suppressedCount} suppressed</span>
+                <span className="text-xs text-text-tertiary">{new Date(entry.lastSentAt).toLocaleString()}</span>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
 
       {/* Firing alerts inline */}
       {data.prometheus.status !== 'unavailable' && data.prometheus.alerts.length > 0 && (

--- a/components/monitoring/types.ts
+++ b/components/monitoring/types.ts
@@ -23,6 +23,12 @@ export interface MonitoringData {
     errors: LogLine[]
     warnings: LogLine[]
   }
+  notificationThrottle: {
+    windowSeconds: number
+    overrides: Record<string, number>
+    suppressedTotal: number
+    entries: Array<{ key: string; lastSentAt: number; suppressedCount: number }>
+  }
   hasIssues: boolean
   fetchedAt: number
   windowMs: number

--- a/components/settings/NotificationsTab.tsx
+++ b/components/settings/NotificationsTab.tsx
@@ -12,6 +12,8 @@ export interface NotificationsSettings {
   notification_on_fix_loop_exhausted: string
   notification_on_review_do_not_ship: string
   notification_on_agent_run_fail: string
+  notification_throttle_window_seconds: string
+  notification_throttle_overrides: string
   [key: string]: string
 }
 
@@ -125,6 +127,36 @@ export function NotificationsTab({
             )}
           </div>
         </form>
+      </div>
+
+      <div className="bg-bg-secondary rounded-lg border border-border">
+        <div className="px-5 py-3 border-b border-border flex items-baseline gap-3">
+          <h3 className="text-sm font-semibold text-text-primary">Throttle</h3>
+          <p className="text-xs text-text-tertiary">Suppress repeated alerts with the same event, project, and agent</p>
+        </div>
+        <div className="px-5 py-4 grid grid-cols-1 md:grid-cols-2 gap-4">
+          <div>
+            <label className="block font-medium text-sm text-text-primary mb-1.5">Window Seconds</label>
+            <input
+              type="number"
+              min="1"
+              value={settings.notification_throttle_window_seconds}
+              onChange={(e) => onChange('notification_throttle_window_seconds', e.target.value)}
+              className={INPUT_CLASS}
+            />
+            <p className="text-xs text-text-tertiary mt-1.5">Default 900. Repeated matching alerts are counted, then included on the next send after the window.</p>
+          </div>
+          <div>
+            <label className="block font-medium text-sm text-text-primary mb-1.5">Override JSON</label>
+            <input
+              type="text"
+              value={settings.notification_throttle_overrides}
+              onChange={(e) => onChange('notification_throttle_overrides', e.target.value)}
+              className={INPUT_CLASS}
+            />
+            <p className="text-xs text-text-tertiary mt-1.5">Set an event to 0 to always send it.</p>
+          </div>
+        </div>
       </div>
 
       {/* Event Toggles */}

--- a/components/settings/constants.ts
+++ b/components/settings/constants.ts
@@ -1,4 +1,4 @@
-export type SettingsFieldKey = 'workspace_path' | 'github_owner' | 'trusted_github_users' | 'claude_provider' | 'claude_bin' | 'lmstudio_model' | 'log_dir' | 'frequency' | 'daytime' | 'weekends' | 'launchagent_prefix' | 'base_prompt' | 'default_model' | 'permission_mode' | 'commit_style' | 'review_verdict_rules' | 'review_fix_max_iterations' |'agent_templates' | 'log_retention_count' | 'log_retention_days' | 'job_row_retention_days' | 'notification_webhook_url' | 'notification_webhook_secret' | 'notification_on_release_success' | 'notification_on_release_fail' | 'notification_on_release_aborted' | 'notification_on_fix_loop_exhausted' | 'notification_on_review_do_not_ship' | 'notification_on_agent_run_fail' | 'pipeline_model_review' | 'pipeline_model_fix' | 'pipeline_model_dod' | 'pipeline_model_commit' | 'dirty_worktree_block_threshold' | 'incremental_review_enabled'
+export type SettingsFieldKey = 'workspace_path' | 'github_owner' | 'trusted_github_users' | 'claude_provider' | 'claude_bin' | 'lmstudio_model' | 'log_dir' | 'frequency' | 'daytime' | 'weekends' | 'launchagent_prefix' | 'base_prompt' | 'default_model' | 'permission_mode' | 'commit_style' | 'review_verdict_rules' | 'review_fix_max_iterations' |'agent_templates' | 'log_retention_count' | 'log_retention_days' | 'job_row_retention_days' | 'notification_webhook_url' | 'notification_webhook_secret' | 'notification_on_release_success' | 'notification_on_release_fail' | 'notification_on_release_aborted' | 'notification_on_fix_loop_exhausted' | 'notification_on_review_do_not_ship' | 'notification_on_agent_run_fail' | 'notification_throttle_window_seconds' | 'notification_throttle_overrides' | 'pipeline_model_review' | 'pipeline_model_fix' | 'pipeline_model_dod' | 'pipeline_model_commit' | 'dirty_worktree_block_threshold' | 'incremental_review_enabled'
 
 export interface FieldDef {
   label: string
@@ -185,6 +185,18 @@ export const FIELDS: Record<SettingsFieldKey, FieldDef> = {
     group: 'notifications' as never,
     span: 1,
   },
+  notification_throttle_window_seconds: {
+    label: 'Notification Throttle Window',
+    help: 'Not used in FIELDS; handled by NotificationsTab',
+    group: 'notifications' as never,
+    span: 1,
+  },
+  notification_throttle_overrides: {
+    label: 'Notification Throttle Overrides',
+    help: 'Not used in FIELDS; handled by NotificationsTab',
+    group: 'notifications' as never,
+    span: 1,
+  },
   pipeline_model_review: {
     label: 'Review Tier',
     help: 'Capability tier used for code review. "Default" uses the workspace Default Model Tier.',
@@ -257,6 +269,8 @@ export const DEFAULTS: Record<SettingsFieldKey, string> = {
   notification_on_fix_loop_exhausted: 'false',
   notification_on_review_do_not_ship: 'false',
   notification_on_agent_run_fail: 'false',
+  notification_throttle_window_seconds: '900',
+  notification_throttle_overrides: '{"release_fail":0,"release_aborted":0}',
   pipeline_model_review: '',
   pipeline_model_fix: '',
   pipeline_model_dod: '',

--- a/docs/API.md
+++ b/docs/API.md
@@ -90,7 +90,7 @@ GitHub board cards carry four TEXT custom fields provisioned by `ensureProjectBo
 ## Health / Monitoring / Stats
 
 - `/api/health` — Health check (GET)
-- `/api/monitoring` — Prometheus + Loki status aggregation (GET); env: `PROMETHEUS_URL`, `LOKI_URL`
+- `/api/monitoring` — Prometheus + Loki status aggregation plus notification throttle state (GET); env: `PROMETHEUS_URL`, `LOKI_URL`
 - `/api/monitoring/pm2-logs` — Tail tamtam PM2 log files (error + out from `~/.pm2/logs/`), last 64 KB; `?limit=` (max 500), `?out=0` to suppress stdout (GET)
 - `/api/stats/usage` — Token usage per project and per agent kind (GET, `?window=24h|7d|30d|all`)
 - `/api/stats/pipeline` — Pipeline health metrics: verdict distribution, recovery-loop stats (`fix` and `fix-push`, attributed by `releaseId` when present and otherwise by the enclosing release window), step durations for the synthetic trigger `agent` step plus `release`, `test`, `review`, `fix`, `commit`, `push`, `pr-wait`, `fix-push`, and `mark-dod` (each with `avg`, `median`, `p95`, `count`, and optional `avgCostUsd` when cost data exists), successful-release duration stats (`mttr.avg`, `mttr.median`, `mttr.p95`, `mttr.count`, optional `mttr.avgCostUsd`), per-project breakdown, and active recovery-budget config snapshot (`maxStepIterations`, `maxFixPushAttempts`, `stepWindowSeconds`; sourced from the same helper as runtime enforcement) (GET, `?window=...`, `?project=`; 60s cache)

--- a/docs/DATABASE.md
+++ b/docs/DATABASE.md
@@ -109,6 +109,18 @@ User-defined reusable prompt blocks.
 
 ---
 
+### `notification_throttle`
+
+Persisted dedupe state for outbound webhook throttling.
+
+| Column | Type | Default | Notes |
+|--------|------|---------|-------|
+| `key` | TEXT | — | PRIMARY KEY; `${event}:${project}:${agent-or-kind}` |
+| `lastSentAt` | INTEGER | — | Unix timestamp in milliseconds for the last delivered alert |
+| `suppressedCount` | INTEGER | `0` | Number of matching alerts suppressed since `lastSentAt` |
+
+---
+
 ### `agents`
 
 Configuration for scheduled automated agents.

--- a/docs/SETTINGS.md
+++ b/docs/SETTINGS.md
@@ -126,11 +126,15 @@ Outbound webhooks for release pipeline events. Never blocks pipeline progress â€
 | `notification_on_review_do_not_ship` | boolean | `false` | Notify when a code review verdict is "DO NOT SHIP". |
 | `notification_on_agent_run_fail` | boolean | `false` | Notify when an agent run fails. |
 | `notification_on_budget_blocked` | boolean | `false` | Notify when a run is refused because the selected agent subscription budget threshold is exceeded. |
+| `notification_throttle_window_seconds` | number | `900` | Suppress repeated webhook notifications with the same event/project/agent key for this many seconds. |
+| `notification_throttle_overrides` | JSON object | `{ "release_fail": 0, "release_aborted": 0 }` | Per-event throttle windows in seconds. Set an event to `0` to always send. |
 
 **Payload format:** 
 - **Slack**: Formatted as block kit with event, project, status, verdict (if review), cost (if available), and a log link.
 - **Discord**: Embedded message with event details and a timestamp.
-- **Generic**: JSON POST with `{ event, project, job_id, status, verdict?, agent?, cost_usd?, log_url?, timestamp }`. The full event union is documented in the later **Payload shape** section below.
+- **Generic**: JSON POST with `{ event, project, job_id, status, verdict?, agent?, cost_usd?, log_url?, suppressedSince?, timestamp }`. The full event union is documented in the later **Payload shape** section below.
+
+When a throttled event is finally sent after suppressed repeats, the payload includes `suppressedSince` and the human message includes the suppressed count.
 
 **Test notification:** Use the "Send Test" button in the Notifications tab to verify webhook connectivity before enabling production events.
 
@@ -178,6 +182,8 @@ Outbound webhook fired when the release pipeline reaches a terminal state. Suppo
 | `notification_on_review_do_not_ship` | boolean | `false` | Fire when a review returns a DO NOT SHIP verdict |
 | `notification_on_agent_run_fail` | boolean | `false` | Fire when any scheduled agent job exits non-zero |
 | `notification_on_budget_blocked` | boolean | `false` | Fire when a run is refused because the selected agent subscription budget threshold is exceeded (debounced once per window+resetsAt) |
+| `notification_throttle_window_seconds` | number | `900` | Suppress repeated webhook notifications with the same event/project/agent key for this many seconds |
+| `notification_throttle_overrides` | JSON object | `{ "release_fail": 0, "release_aborted": 0 }` | Per-event throttle windows in seconds; `0` always sends |
 
 ### Subscription Budget
 
@@ -291,6 +297,7 @@ notification_webhook_secret, notification_on_release_success,
 notification_on_release_fail, notification_on_release_aborted,
 notification_on_fix_loop_exhausted, notification_on_review_do_not_ship,
 notification_on_agent_run_fail, notification_on_budget_blocked,
+notification_throttle_window_seconds, notification_throttle_overrides,
 budget_block_runs_enabled, budget_subscription_providers,
 budget_block_at_pct, budget_warn_at_pct, pipeline_model_review,
 pipeline_model_fix, pipeline_model_dod, pipeline_model_commit,

--- a/lib/db/index.ts
+++ b/lib/db/index.ts
@@ -173,6 +173,16 @@ sqlite.exec(`
     ON queued_agent_runs (project, agent_id);
 `);
 
+// Per-notification dedupe state. Kept in SQLite so flapping webhook
+// suppression survives server restarts.
+sqlite.exec(`
+  CREATE TABLE IF NOT EXISTS notification_throttle (
+    key TEXT PRIMARY KEY,
+    last_sent_at INTEGER NOT NULL,
+    suppressed_count INTEGER NOT NULL DEFAULT 0
+  );
+`);
+
 // Migrate: add token/duration/session columns to jobs if missing
 try {
   sqlite.exec('ALTER TABLE jobs ADD COLUMN duration_ms INTEGER');

--- a/lib/db/migrations/0017_slimy_justin_hammer.sql
+++ b/lib/db/migrations/0017_slimy_justin_hammer.sql
@@ -1,0 +1,5 @@
+CREATE TABLE `notification_throttle` (
+	`key` text PRIMARY KEY NOT NULL,
+	`last_sent_at` integer NOT NULL,
+	`suppressed_count` integer DEFAULT 0 NOT NULL
+);

--- a/lib/db/migrations/meta/0017_snapshot.json
+++ b/lib/db/migrations/meta/0017_snapshot.json
@@ -1,0 +1,960 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "729084b7-ddf6-4735-8414-070407c7d358",
+  "prevId": "dd86d657-bce9-43ab-a237-3613d13868e0",
+  "tables": {
+    "agents": {
+      "name": "agents",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project": {
+          "name": "project",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "skill_ids": {
+          "name": "skill_ids",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'normal'"
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "schedule": {
+          "name": "schedule",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "runner": {
+          "name": "runner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pm2'"
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "doc_paths": {
+          "name": "doc_paths",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "prerequisite_command": {
+          "name": "prerequisite_command",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "gh_issues_cache": {
+      "name": "gh_issues_cache",
+      "columns": {
+        "project": {
+          "name": "project",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "repo": {
+          "name": "repo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "prs": {
+          "name": "prs",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "issues": {
+          "name": "issues",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "fetched_at": {
+          "name": "fetched_at",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "gh_status": {
+      "name": "gh_status",
+      "columns": {
+        "project": {
+          "name": "project",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "release_tag": {
+          "name": "release_tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ci": {
+          "name": "ci",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ci_failed_url": {
+          "name": "ci_failed_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "head_sha": {
+          "name": "head_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "local_head_sha": {
+          "name": "local_head_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "fetched_at": {
+          "name": "fetched_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "jobs": {
+      "name": "jobs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project": {
+          "name": "project",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pid": {
+          "name": "pid",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "log_path": {
+          "name": "log_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "exit_code": {
+          "name": "exit_code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "seen": {
+          "name": "seen",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cache_read_tokens": {
+          "name": "cache_read_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cache_create_tokens": {
+          "name": "cache_create_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_prompt": {
+          "name": "user_prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "context_meta": {
+          "name": "context_meta",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "parent_job_id": {
+          "name": "parent_job_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "gh_issue_number": {
+          "name": "gh_issue_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "gh_issue_repo": {
+          "name": "gh_issue_repo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "gh_issue_title": {
+          "name": "gh_issue_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "log_pruned": {
+          "name": "log_pruned",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "verdict": {
+          "name": "verdict",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cost_usd": {
+          "name": "cost_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "release_id": {
+          "name": "release_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "aborted_at": {
+          "name": "aborted_at",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "prompt_bytes": {
+          "name": "prompt_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "work_summary": {
+          "name": "work_summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "modified_files": {
+          "name": "modified_files",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "notification_throttle": {
+      "name": "notification_throttle",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_sent_at": {
+          "name": "last_sent_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "suppressed_count": {
+          "name": "suppressed_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "pipeline_locks": {
+      "name": "pipeline_locks",
+      "columns": {
+        "project": {
+          "name": "project",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "locked_by_job_id": {
+          "name": "locked_by_job_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "acquired_at": {
+          "name": "acquired_at",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "projects": {
+      "name": "projects",
+      "columns": {
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "github": {
+          "name": "github",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "priority": {
+          "name": "priority",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "custom_actions": {
+          "name": "custom_actions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "test_command": {
+          "name": "test_command",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tests_disabled": {
+          "name": "tests_disabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "review_disabled": {
+          "name": "review_disabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "test_cron_enabled": {
+          "name": "test_cron_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "test_cron_schedule": {
+          "name": "test_cron_schedule",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "auto_commit_enabled": {
+          "name": "auto_commit_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "auto_push_enabled": {
+          "name": "auto_push_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "auto_pr_merge_enabled": {
+          "name": "auto_pr_merge_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "release_after_run": {
+          "name": "release_after_run",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "issue_auto_branch": {
+          "name": "issue_auto_branch",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": true
+        },
+        "last_push_error": {
+          "name": "last_push_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_push_at": {
+          "name": "last_push_at",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "review_prompt_addendum": {
+          "name": "review_prompt_addendum",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "fix_prompt_addendum": {
+          "name": "fix_prompt_addendum",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "website": {
+          "name": "website",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "qa_url": {
+          "name": "qa_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "queued_agent_runs": {
+      "name": "queued_agent_runs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "project": {
+          "name": "project",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "agent_name": {
+          "name": "agent_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "triggered_by": {
+          "name": "triggered_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'manual'"
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "enqueued_at": {
+          "name": "enqueued_at",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "queued_agent_runs_project_agent": {
+          "name": "queued_agent_runs_project_agent",
+          "columns": [
+            "project",
+            "agent_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "recommendations": {
+      "name": "recommendations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project": {
+          "name": "project",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_kind": {
+          "name": "source_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "agent_name": {
+          "name": "agent_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "detail": {
+          "name": "detail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'open'"
+        },
+        "payload": {
+          "name": "payload",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "settings": {
+      "name": "settings",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "skills": {
+      "name": "skills",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/lib/db/migrations/meta/_journal.json
+++ b/lib/db/migrations/meta/_journal.json
@@ -120,6 +120,13 @@
       "when": 1778509748400,
       "tag": "0016_noisy_dazzler",
       "breakpoints": true
+    },
+    {
+      "idx": 17,
+      "version": "6",
+      "when": 1778644106521,
+      "tag": "0017_slimy_justin_hammer",
+      "breakpoints": true
     }
   ]
 }

--- a/lib/db/schema.ts
+++ b/lib/db/schema.ts
@@ -145,3 +145,9 @@ export const queuedAgentRuns = sqliteTable('queued_agent_runs', {
 }, (t) => ({
   projectAgentUniq: uniqueIndex('queued_agent_runs_project_agent').on(t.project, t.agentId),
 }));
+
+export const notificationThrottle = sqliteTable('notification_throttle', {
+  key: text('key').primaryKey(),
+  lastSentAt: integer('last_sent_at').notNull(),
+  suppressedCount: integer('suppressed_count').notNull().default(0),
+});

--- a/lib/shared/config.ts
+++ b/lib/shared/config.ts
@@ -62,6 +62,8 @@ export interface TamTamConfig {
   notification_on_fix_loop_exhausted: boolean;
   notification_on_review_do_not_ship: boolean;
   notification_on_agent_run_fail: boolean;
+  notification_throttle_window_seconds: number;
+  notification_throttle_overrides: Record<string, number>;
   pipeline_model_review: string;
   pipeline_model_fix: string;
   pipeline_model_dod: string;
@@ -130,6 +132,8 @@ const DEFAULTS: TamTamConfig = {
   notification_on_fix_loop_exhausted: false,
   notification_on_review_do_not_ship: false,
   notification_on_agent_run_fail: false,
+  notification_throttle_window_seconds: 900,
+  notification_throttle_overrides: { release_fail: 0, release_aborted: 0 },
   // Empty string = use the per-step sensible default (review/fix → workspace
   // default_model; dod/commit → fast since they're cheap classification tasks).
   pipeline_model_review: '',
@@ -274,6 +278,14 @@ export function getSettings(): TamTamConfig {
     notification_on_fix_loop_exhausted: map.notification_on_fix_loop_exhausted === 'true',
     notification_on_review_do_not_ship: map.notification_on_review_do_not_ship === 'true',
     notification_on_agent_run_fail: map.notification_on_agent_run_fail === 'true',
+    notification_throttle_window_seconds: parseIntOr(
+      map.notification_throttle_window_seconds,
+      DEFAULTS.notification_throttle_window_seconds
+    ),
+    notification_throttle_overrides: parseJsonNumberMap(
+      map.notification_throttle_overrides,
+      DEFAULTS.notification_throttle_overrides
+    ),
     pipeline_model_review: resolveModelAlias(map.pipeline_model_review),
     pipeline_model_fix: resolveModelAlias(map.pipeline_model_fix),
     pipeline_model_dod: resolveModelAlias(map.pipeline_model_dod),
@@ -327,6 +339,22 @@ function parseJsonObject(v: string | undefined): Record<string, string> {
     return parsed && typeof parsed === 'object' && !Array.isArray(parsed) ? parsed as Record<string, string> : {};
   } catch {
     return {};
+  }
+}
+
+function parseJsonNumberMap(v: string | undefined, fallback: Record<string, number>): Record<string, number> {
+  if (!v) return fallback;
+  try {
+    const parsed = JSON.parse(v);
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return fallback;
+    const out: Record<string, number> = {};
+    for (const [key, value] of Object.entries(parsed)) {
+      const n = typeof value === 'number' ? value : Number.parseInt(String(value), 10);
+      if (Number.isFinite(n) && n >= 0) out[key] = n;
+    }
+    return { ...fallback, ...out };
+  } catch {
+    return fallback;
   }
 }
 

--- a/lib/shared/job-control.ts
+++ b/lib/shared/job-control.ts
@@ -121,6 +121,7 @@ function fireBudgetBlockedNotification(
     job_id: '-',
     status: 'failed',
     message: `Subscription quota gate tripped: ${window} at ${utilization.toFixed(0)}% blocked attempt to ${action}. Resets ${resetsAt ?? 'unknown'}.`,
+    throttleKeySuffix: `budget:${key}`,
     timestamp: now,
   });
 }

--- a/lib/shared/notifications.ts
+++ b/lib/shared/notifications.ts
@@ -1,4 +1,6 @@
 import { createHmac } from 'crypto';
+import { eq } from 'drizzle-orm';
+import { db, schema } from '@/lib/db';
 import { getSettings } from '@/lib/shared/config';
 
 export type NotificationEvent =
@@ -20,6 +22,8 @@ export interface NotificationPayload {
   cost_usd?: number;
   log_url?: string;
   message?: string;
+  suppressedSince?: number;
+  throttleKeySuffix?: string;
   timestamp: number;
 }
 
@@ -28,6 +32,8 @@ interface NotificationConfig {
   webhook_secret: string;
   enabled: boolean;
 }
+
+const notificationQueues = new Map<string, Promise<void>>();
 
 function getNotificationConfig(event: NotificationEvent): NotificationConfig {
   const settings = getSettings();
@@ -71,6 +77,121 @@ function detectWebhookType(url: string): 'slack' | 'discord' | 'generic' {
   if (url.includes('hooks.slack.com')) return 'slack';
   if (url.includes('discord.com/api/webhooks')) return 'discord';
   return 'generic';
+}
+
+function throttleSubject(payload: NotificationPayload): string {
+  if (payload.agent) return payload.agent;
+  switch (payload.event) {
+    case 'agent_run_fail': return 'agent';
+    case 'review_do_not_ship': return 'review';
+    case 'fix_loop_exhausted': return 'fix';
+    case 'budget_blocked': return 'budget';
+    default: return 'release';
+  }
+}
+
+function throttleKey(payload: NotificationPayload): string {
+  if (payload.throttleKeySuffix) {
+    return `${payload.event}:${payload.project}:${payload.throttleKeySuffix}`;
+  }
+  return `${payload.event}:${payload.project}:${throttleSubject(payload)}`;
+}
+
+function throttleWindowMs(payload: NotificationPayload, settings: ReturnType<typeof getSettings>): number {
+  const override = settings.notification_throttle_overrides[payload.event];
+  const seconds = override ?? settings.notification_throttle_window_seconds;
+  return Math.max(0, seconds) * 1000;
+}
+
+function withSuppressedMessage(payload: NotificationPayload, suppressedSince: number): NotificationPayload {
+  if (suppressedSince <= 0) return payload;
+  const suffix = `${suppressedSince} more notification${suppressedSince === 1 ? '' : 's'} suppressed since the last alert.`;
+  return {
+    ...payload,
+    suppressedSince,
+    message: payload.message ? `${payload.message}\n\n${suffix}` : suffix,
+  };
+}
+
+type ThrottleSendState =
+  | {
+      key: string;
+      now: number;
+      kind: 'insert';
+    }
+  | {
+      key: string;
+      now: number;
+      kind: 'update';
+    };
+
+function shouldSend(
+  payload: NotificationPayload,
+): { send: boolean; payload: NotificationPayload; state: ThrottleSendState | null } {
+  const settings = getSettings();
+  const windowMs = throttleWindowMs(payload, settings);
+  if (windowMs <= 0) return { send: true, payload, state: null };
+
+  const now = payload.timestamp || Date.now();
+  const key = throttleKey(payload);
+  const existing = db.select()
+    .from(schema.notificationThrottle)
+    .where(eq(schema.notificationThrottle.key, key))
+    .get();
+
+  if (!existing) {
+    return {
+      send: true,
+      payload,
+      state: { key, now, kind: 'insert' },
+    };
+  }
+
+  if (now - existing.lastSentAt < windowMs) {
+    db.update(schema.notificationThrottle)
+      .set({ suppressedCount: existing.suppressedCount + 1 })
+      .where(eq(schema.notificationThrottle.key, key))
+      .run();
+    return { send: false, payload, state: null };
+  }
+
+  return {
+    send: true,
+    payload: withSuppressedMessage(payload, existing.suppressedCount),
+    state: { key, now, kind: 'update' },
+  };
+}
+
+function markThrottleDelivered(state: ThrottleSendState | null) {
+  if (!state) return;
+  if (state.kind === 'insert') {
+    db.insert(schema.notificationThrottle)
+      .values({ key: state.key, lastSentAt: state.now, suppressedCount: 0 })
+      .run();
+    return;
+  }
+  db.update(schema.notificationThrottle)
+    .set({ lastSentAt: state.now, suppressedCount: 0 })
+    .where(eq(schema.notificationThrottle.key, state.key))
+    .run();
+}
+
+function enqueueNotification(key: string, task: () => Promise<void>) {
+  const previous = notificationQueues.get(key) ?? Promise.resolve();
+  const next = previous
+    .catch(() => {})
+    .then(task)
+    .finally(() => {
+      if (notificationQueues.get(key) === next) {
+        notificationQueues.delete(key);
+      }
+    });
+  notificationQueues.set(key, next);
+}
+
+function toGenericBody(payload: NotificationPayload): Record<string, unknown> {
+  const { throttleKeySuffix: _throttleKeySuffix, ...body } = payload;
+  return body as unknown as Record<string, unknown>;
 }
 
 function formatSlackMessage(payload: NotificationPayload): Record<string, unknown> {
@@ -179,24 +300,37 @@ export async function notify(payload: NotificationPayload): Promise<void> {
   if (!config.enabled || !config.webhook_url) {
     return;
   }
+  const queuedPayload = { ...payload };
+  const queueKey = throttleKey(queuedPayload);
 
-  const webhookType = detectWebhookType(config.webhook_url);
-  let body: Record<string, unknown>;
+  // Never block pipeline progress — work is serialized per throttle key in the
+  // background so the persisted throttle state still tracks delivered alerts.
+  enqueueNotification(queueKey, async () => {
+    const throttle = shouldSend(queuedPayload);
+    if (!throttle.send) return;
+    const resolvedPayload = throttle.payload;
+    const webhookType = detectWebhookType(config.webhook_url);
+    let body: Record<string, unknown>;
 
-  if (webhookType === 'slack') {
-    body = formatSlackMessage(payload);
-  } else if (webhookType === 'discord') {
-    body = formatDiscordMessage(payload);
-  } else {
-    body = payload as unknown as Record<string, unknown>;
-  }
+    if (webhookType === 'slack') {
+      body = formatSlackMessage(resolvedPayload);
+    } else if (webhookType === 'discord') {
+      body = formatDiscordMessage(resolvedPayload);
+    } else {
+      body = toGenericBody(resolvedPayload);
+    }
 
-  const bodyJson = JSON.stringify(body);
-  const signature = config.webhook_secret ? signPayload(bodyJson, config.webhook_secret) : undefined;
+    const bodyJson = JSON.stringify(body);
+    const signature = config.webhook_secret ? signPayload(bodyJson, config.webhook_secret) : undefined;
 
-  // Never block pipeline progress — fire and forget
-  postWebhook(config.webhook_url, body, signature).catch((e) => {
-    console.error(`[notifications] failed to send ${payload.event} notification:`, e);
+    try {
+      const delivered = await postWebhook(config.webhook_url, body, signature);
+      if (delivered) {
+        markThrottleDelivered(throttle.state);
+      }
+    } catch (e) {
+      console.error(`[notifications] failed to send ${resolvedPayload.event} notification:`, e);
+    }
   });
 }
 
@@ -222,7 +356,7 @@ export async function sendTestNotification(webhookUrl: string, webhookSecret: st
   } else if (webhookType === 'discord') {
     body = formatDiscordMessage(payload);
   } else {
-    body = payload as unknown as Record<string, unknown>;
+    body = toGenericBody(payload);
   }
 
   const bodyJson = JSON.stringify(body);


### PR DESCRIPTION
Closes #86

Implemented notification throttle/dedupe support for issue #86 and applied the additive migration.

---
Implemented via TamTam from issue [#86](https://github.com/3h4x/tamtam/issues/86).