### PR TITLE
fix: Expose retention cleanup telemetry so maintenance is auditable

### DIFF
--- a/__tests__/api/monitoring.test.ts
+++ b/__tests__/api/monitoring.test.ts
@@ -32,6 +32,11 @@ function createTestDb() {
       last_sent_at INTEGER NOT NULL,
       suppressed_count INTEGER NOT NULL DEFAULT 0
     );
+    CREATE TABLE maintenance_status (
+      key TEXT PRIMARY KEY,
+      value TEXT NOT NULL,
+      updated_at REAL NOT NULL
+    );
   `);
   return { sqlite, db: drizzle(sqlite, { schema }) };
 }
@@ -52,6 +57,9 @@ describe('GET /api/monitoring', () => {
       getSettings: () => ({
         notification_throttle_window_seconds: 900,
         notification_throttle_overrides: { release_fail: 0, release_aborted: 0 },
+        log_retention_count: 200,
+        log_retention_days: 30,
+        job_row_retention_days: 180,
       }),
     }));
     fetchSpy = vi.fn();
@@ -80,6 +88,15 @@ describe('GET /api/monitoring', () => {
       overrides: { release_fail: 0, release_aborted: 0 },
       suppressedTotal: 0,
       entries: [],
+    });
+    expect(data.retention).toEqual({
+      policy: {
+        logRetentionCount: 200,
+        logRetentionDays: 30,
+        jobRowRetentionDays: 180,
+      },
+      lastProjectLogCleanup: null,
+      lastNightlyCleanup: null,
     });
   });
 
@@ -266,6 +283,57 @@ describe('GET /api/monitoring', () => {
     expect(data.notificationThrottle.entries).toHaveLength(20);
     expect(data.notificationThrottle.entries[0].key).toBe('agent_run_fail:p:agent-25');
     expect(data.notificationThrottle.entries[19].key).toBe('agent_run_fail:p:agent-6');
+  });
+
+  it('includes separate persisted nightly and project log retention summaries', async () => {
+    const nightlySummary = {
+      type: 'nightly',
+      status: 'completed',
+      startedAt: 1700000000,
+      finishedAt: 1700000010,
+      rowsScanned: 4,
+      rowsDeleted: 3,
+      skippedRunningRows: 1,
+      errorCount: 0,
+      lastError: null,
+      sqliteMaintenance: {
+        status: 'completed',
+        startedAt: 1700000005,
+        finishedAt: 1700000010,
+        activeJobs: 0,
+        checkpointRan: true,
+        vacuumRan: true,
+      },
+    };
+    const projectLogSummary = {
+      type: 'project_logs',
+      project: 'proj',
+      status: 'completed',
+      startedAt: 1700000020,
+      finishedAt: 1700000030,
+      rowsScanned: 4,
+      rowsEligible: 2,
+      rowsUpdated: 2,
+      logFilesDeleted: 2,
+      bytesReclaimed: 4096,
+      skippedRunningRows: 0,
+      errorCount: 0,
+      lastError: null,
+    };
+    testDb.sqlite.prepare('INSERT INTO maintenance_status (key, value, updated_at) VALUES (?, ?, ?)').run('retention:nightly:last', JSON.stringify(nightlySummary), 1700000010);
+    testDb.sqlite.prepare('INSERT INTO maintenance_status (key, value, updated_at) VALUES (?, ?, ?)').run('retention:project-logs:last', JSON.stringify(projectLogSummary), 1700000030);
+    fetchSpy.mockRejectedValue(new Error('connection refused'));
+
+    const res = await GET(makeRequest());
+    const data = await res.json();
+
+    expect(data.retention.policy).toEqual({
+      logRetentionCount: 200,
+      logRetentionDays: 30,
+      jobRowRetentionDays: 180,
+    });
+    expect(data.retention.lastNightlyCleanup).toEqual(nightlySummary);
+    expect(data.retention.lastProjectLogCleanup).toEqual(projectLogSummary);
   });
 
   it('loki queries exclude info/debug/trace log levels', async () => {

--- a/__tests__/components/monitoring-overview-tab.test.tsx
+++ b/__tests__/components/monitoring-overview-tab.test.tsx
@@ -1,0 +1,163 @@
+/* @vitest-environment jsdom */
+
+import React from 'react'
+import { afterEach, describe, expect, it } from 'vitest'
+import { createRoot } from 'react-dom/client'
+import { flushSync } from 'react-dom'
+import { OverviewTab } from '@/components/monitoring/OverviewTab'
+import type { MonitoringData } from '@/components/monitoring/types'
+import type { Pm2LogData } from '@/components/monitoring/Pm2LogPanel'
+
+function buildMonitoringData(overrides: Partial<MonitoringData> = {}): MonitoringData {
+  return {
+    prometheus: {
+      status: 'ok',
+      alerts: [],
+      services: [],
+    },
+    loki: {
+      status: 'ok',
+      errors: [],
+      warnings: [],
+    },
+    notificationThrottle: {
+      windowSeconds: 900,
+      overrides: {},
+      suppressedTotal: 0,
+      entries: [],
+    },
+    retention: {
+      policy: {
+        logRetentionCount: 200,
+        logRetentionDays: 30,
+        jobRowRetentionDays: 180,
+      },
+      lastNightlyCleanup: {
+        type: 'nightly',
+        status: 'completed',
+        startedAt: 1_700_000_000,
+        finishedAt: 1_700_000_010,
+        rowsScanned: 4,
+        rowsDeleted: 3,
+        skippedRunningRows: 0,
+        errorCount: 0,
+        lastError: null,
+        sqliteMaintenance: {
+          status: 'completed',
+          startedAt: 1_700_000_000,
+          finishedAt: 1_700_000_010,
+          activeJobs: 0,
+          checkpointRan: true,
+          vacuumRan: true,
+        },
+      },
+      lastProjectLogCleanup: {
+        type: 'project_logs',
+        project: 'proj',
+        status: 'completed',
+        startedAt: 1_700_000_020,
+        finishedAt: 1_700_000_030,
+        rowsScanned: 4,
+        rowsEligible: 1,
+        rowsUpdated: 1,
+        logFilesDeleted: 1,
+        bytesReclaimed: 2048,
+        skippedRunningRows: 0,
+        errorCount: 0,
+        lastError: null,
+      },
+    },
+    hasIssues: false,
+    fetchedAt: 1_700_000_100,
+    windowMs: 15 * 60 * 1000,
+    config: {
+      prometheusUrl: 'http://localhost:9090',
+      lokiUrl: 'http://localhost:3100',
+    },
+    ...overrides,
+  }
+}
+
+function renderOverview(data: MonitoringData, pm2Logs: Pm2LogData | null = null) {
+  const container = document.createElement('div')
+  document.body.appendChild(container)
+  const root = createRoot(container)
+
+  flushSync(() => {
+    root.render(<OverviewTab data={data} pm2Logs={pm2Logs} window_="15m" />)
+  })
+
+  return {
+    container,
+    unmount: () => {
+      flushSync(() => root.unmount())
+      container.remove()
+    },
+  }
+}
+
+describe('Monitoring OverviewTab', () => {
+  afterEach(() => {
+    document.body.innerHTML = ''
+  })
+
+  it('marks retention as an issue when project log cleanup failed even if nightly cleanup succeeded', () => {
+    const data = buildMonitoringData({
+      retention: {
+        policy: {
+          logRetentionCount: 200,
+          logRetentionDays: 30,
+          jobRowRetentionDays: 180,
+        },
+        lastNightlyCleanup: {
+          type: 'nightly',
+          status: 'completed',
+          startedAt: 1_700_000_000,
+          finishedAt: 1_700_000_010,
+          rowsScanned: 4,
+          rowsDeleted: 3,
+          skippedRunningRows: 0,
+          errorCount: 0,
+          lastError: null,
+          sqliteMaintenance: {
+            status: 'completed',
+            startedAt: 1_700_000_000,
+            finishedAt: 1_700_000_010,
+            activeJobs: 0,
+            checkpointRan: true,
+            vacuumRan: true,
+          },
+        },
+        lastProjectLogCleanup: {
+          type: 'project_logs',
+          project: 'proj',
+          status: 'failed',
+          startedAt: 1_700_000_020,
+          finishedAt: 1_700_000_030,
+          rowsScanned: 4,
+          rowsEligible: 2,
+          rowsUpdated: 1,
+          logFilesDeleted: 0,
+          bytesReclaimed: 0,
+          skippedRunningRows: 0,
+          errorCount: 1,
+          lastError: 'EPERM unlink denied',
+        },
+      },
+    })
+
+    const { container, unmount } = renderOverview(data)
+
+    expect(container.textContent).toContain('Retention')
+    expect(container.textContent).toContain('failed')
+    expect(container.textContent).toContain('EPERM unlink denied')
+    expect(container.textContent).toContain('completed')
+
+    const cards = Array.from(container.querySelectorAll('div.rounded-lg.border'))
+    const retentionCard = cards.find((card) => card.textContent?.includes('Retention'))
+    expect(retentionCard?.className).toContain('text-status-warning')
+    expect(retentionCard?.textContent).toContain('failed · 0 files, 0 B · EPERM unlink denied')
+
+    unmount()
+  })
+})

--- a/__tests__/lib/db-bootstrap.test.ts
+++ b/__tests__/lib/db-bootstrap.test.ts
@@ -3,6 +3,8 @@ import Database from 'better-sqlite3';
 import { mkdtempSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
+import { drizzle } from 'drizzle-orm/better-sqlite3';
+import { migrate } from 'drizzle-orm/better-sqlite3/migrator';
 
 function createDbWithSettings(rows: Array<{ key: string; value: string }>) {
   const dir = mkdtempSync(join(tmpdir(), 'tamtam-db-bootstrap-'));
@@ -90,6 +92,63 @@ describe('db bootstrap migrations', () => {
     expect(queuedAgentRuns?.name).toBe('queued_agent_runs');
     expect(recommendations?.name).toBe('recommendations');
     expect(queuedIndex?.name).toBe('queued_agent_runs_project_agent');
+  });
+
+  it('keeps maintenance_status compatible with the numbered migration after runtime bootstrap', async () => {
+    const dbPath = createDbWithSettings([]);
+    process.env.TAMTAM_DB_PATH = dbPath;
+
+    await import('@/lib/db');
+
+    const migratedDir = mkdtempSync(join(tmpdir(), 'tamtam-db-bootstrap-migrate-'));
+    const migratedDbPath = join(migratedDir, 'baseline.db');
+    const migratedSqlite = new Database(migratedDbPath);
+    try {
+      migrate(drizzle(migratedSqlite), { migrationsFolder: join(process.cwd(), 'lib', 'db', 'migrations') });
+      const previousMigrationRows = migratedSqlite.prepare(`
+        SELECT hash, created_at
+        FROM __drizzle_migrations
+        ORDER BY created_at ASC
+        LIMIT 19
+      `).all() as Array<{ hash: string; created_at: number }>;
+      migratedSqlite.close();
+
+      const sqlite = new Database(dbPath);
+      try {
+        sqlite.exec(`
+          CREATE TABLE IF NOT EXISTS "__drizzle_migrations" (
+            id SERIAL PRIMARY KEY,
+            hash text NOT NULL,
+            created_at numeric
+          )
+        `);
+        const insertMigration = sqlite.prepare(`
+          INSERT INTO "__drizzle_migrations" (hash, created_at)
+          VALUES (?, ?)
+        `);
+        for (const row of previousMigrationRows) {
+          insertMigration.run(row.hash, row.created_at);
+        }
+
+        expect(() =>
+          migrate(drizzle(sqlite), { migrationsFolder: join(process.cwd(), 'lib', 'db', 'migrations') })
+        ).not.toThrow();
+
+        const maintenanceStatus = sqlite.prepare(`
+          SELECT name
+          FROM sqlite_master
+          WHERE type = 'table' AND name = 'maintenance_status'
+        `).get() as { name: string } | undefined;
+
+        expect(maintenanceStatus?.name).toBe('maintenance_status');
+      } finally {
+        sqlite.close();
+      }
+    } finally {
+      try {
+        migratedSqlite.close();
+      } catch {}
+    }
   });
 
   it('backfills doc_paths and provider columns onto legacy agents tables', async () => {

--- a/__tests__/lib/retention.test.ts
+++ b/__tests__/lib/retention.test.ts
@@ -45,6 +45,11 @@ function createTestDb() {
       modified_files TEXT,
       provider TEXT
     );
+    CREATE TABLE IF NOT EXISTS maintenance_status (
+      key TEXT PRIMARY KEY,
+      value TEXT NOT NULL,
+      updated_at REAL NOT NULL
+    );
   `);
   return { sqlite, db: drizzle(sqlite, { schema }) };
 }
@@ -74,6 +79,8 @@ describe('pruneProjectLogs', () => {
   let tempDir: string;
   let testDb: ReturnType<typeof createTestDb>;
   let pruneProjectLogs: typeof import('@/lib/jobs/retention').pruneProjectLogs;
+  let getLatestProjectLogRetentionSummary: typeof import('@/lib/jobs/retention').getLatestProjectLogRetentionSummary;
+  let getLatestNightlyRetentionSummary: typeof import('@/lib/jobs/retention').getLatestNightlyRetentionSummary;
 
   beforeEach(async () => {
     tempDir = mkdtempSync(join(tmpdir(), 'tamtam-retention-'));
@@ -82,6 +89,8 @@ describe('pruneProjectLogs', () => {
     vi.doMock('@/lib/db', () => ({ db: testDb.db, schema }));
     const mod = await import('@/lib/jobs/retention');
     pruneProjectLogs = mod.pruneProjectLogs;
+    getLatestProjectLogRetentionSummary = mod.getLatestProjectLogRetentionSummary;
+    getLatestNightlyRetentionSummary = mod.getLatestNightlyRetentionSummary;
   });
 
   afterEach(() => {
@@ -109,7 +118,7 @@ describe('pruneProjectLogs', () => {
       insertJob(`proj-job-${i}`, 'proj', now - (5 - i) * 100, now - (5 - i) * 50, p);
     }
 
-    pruneProjectLogs('proj', cfg);
+    const summary = pruneProjectLogs('proj', cfg);
 
     // Newest 3 (indices 2, 3, 4) should survive; oldest 2 (0, 1) pruned.
     expect(existsSync(logPaths[0])).toBe(false);
@@ -117,6 +126,19 @@ describe('pruneProjectLogs', () => {
     expect(existsSync(logPaths[2])).toBe(true);
     expect(existsSync(logPaths[3])).toBe(true);
     expect(existsSync(logPaths[4])).toBe(true);
+    expect(summary).toMatchObject({
+      type: 'project_logs',
+      project: 'proj',
+      status: 'completed',
+      rowsScanned: 5,
+      rowsEligible: 2,
+      rowsUpdated: 2,
+      logFilesDeleted: 2,
+      bytesReclaimed: 8,
+      errorCount: 0,
+    });
+    expect(getLatestProjectLogRetentionSummary()).toMatchObject({ type: 'project_logs', rowsUpdated: 2 });
+    expect(getLatestNightlyRetentionSummary()).toBeNull();
   });
 
   it('sets log_pruned=true on pruned rows', () => {
@@ -196,11 +218,12 @@ describe('pruneProjectLogs', () => {
       insertJob(`proj-job-${i}`, 'proj', now - (i + 1) * 100, now - (i + 1) * 50, p);
     }
 
-    pruneProjectLogs('proj', ageOnlyCfg);
+    const summary = pruneProjectLogs('proj', ageOnlyCfg);
 
     for (const p of paths) expect(existsSync(p)).toBe(true);
     const rows = testDb.db.select({ id: schema.jobs.id, logPruned: schema.jobs.logPruned }).from(schema.jobs).all();
     expect(rows.every(r => !r.logPruned)).toBe(true);
+    expect(summary.status).toBe('disabled');
   });
 
   it('only prunes logs for the given project', () => {
@@ -227,6 +250,8 @@ describe('pruneProjectLogs', () => {
 describe('runNightlyCleanup', () => {
   let testDb: ReturnType<typeof createTestDb>;
   let runNightlyCleanup: typeof import('@/lib/jobs/retention').runNightlyCleanup;
+  let getLatestProjectLogRetentionSummary: typeof import('@/lib/jobs/retention').getLatestProjectLogRetentionSummary;
+  let getLatestNightlyRetentionSummary: typeof import('@/lib/jobs/retention').getLatestNightlyRetentionSummary;
 
   beforeEach(async () => {
     vi.resetModules();
@@ -234,6 +259,8 @@ describe('runNightlyCleanup', () => {
     vi.doMock('@/lib/db', () => ({ db: testDb.db, schema }));
     const mod = await import('@/lib/jobs/retention');
     runNightlyCleanup = mod.runNightlyCleanup;
+    getLatestProjectLogRetentionSummary = mod.getLatestProjectLogRetentionSummary;
+    getLatestNightlyRetentionSummary = mod.getLatestNightlyRetentionSummary;
   });
 
   afterEach(() => {
@@ -255,20 +282,44 @@ describe('runNightlyCleanup', () => {
     insertJob('old-job', 'proj', now - 100 * 86400, now - 100 * 86400 + 60);
     insertJob('new-job', 'proj', now - 10, now);
 
-    runNightlyCleanup(cfg);
+    const summary = runNightlyCleanup(cfg);
 
     const rows = testDb.db.select({ id: schema.jobs.id }).from(schema.jobs).all();
     expect(rows.map(r => r.id)).toEqual(['new-job']);
+    expect(summary).toMatchObject({
+      type: 'nightly',
+      status: 'completed',
+      rowsScanned: 1,
+      rowsDeleted: 1,
+      skippedRunningRows: 0,
+      errorCount: 0,
+      sqliteMaintenance: {
+        status: 'completed',
+        checkpointRan: true,
+        vacuumRan: true,
+      },
+    });
+    expect(getLatestNightlyRetentionSummary()).toMatchObject({ type: 'nightly', rowsDeleted: 1 });
+    expect(getLatestProjectLogRetentionSummary()).toBeNull();
   });
 
   it('does not delete running jobs even if started long ago', () => {
     const now = Date.now() / 1000;
     insertJob('long-running', 'proj', now - 200 * 86400, null);
+    insertJob('old-job', 'proj', now - 100 * 86400, now - 100 * 86400 + 60);
 
-    runNightlyCleanup(cfg);
+    const summary = runNightlyCleanup(cfg);
 
     const rows = testDb.db.select({ id: schema.jobs.id }).from(schema.jobs).all();
     expect(rows.map(r => r.id)).toEqual(['long-running']);
+    expect(summary.skippedRunningRows).toBe(1);
+    expect(summary.sqliteMaintenance).toMatchObject({
+      status: 'skipped',
+      reason: 'active_jobs',
+      activeJobs: 1,
+      checkpointRan: false,
+      vacuumRan: false,
+    });
   });
 
   it('treats job_row_retention_days=0 as disabled (does not delete anything)', () => {
@@ -276,10 +327,12 @@ describe('runNightlyCleanup', () => {
     insertJob('very-old', 'proj', now - 1000 * 86400, now - 1000 * 86400 + 60);
     insertJob('old', 'proj', now - 100 * 86400, now - 100 * 86400 + 60);
 
-    runNightlyCleanup({ log_retention_count: 200, log_retention_days: 30, job_row_retention_days: 0 });
+    const summary = runNightlyCleanup({ log_retention_count: 200, log_retention_days: 30, job_row_retention_days: 0 });
 
     const rows = testDb.db.select({ id: schema.jobs.id }).from(schema.jobs).all();
     expect(rows.map(r => r.id).sort()).toEqual(['old', 'very-old']);
+    expect(summary.status).toBe('disabled');
+    expect(summary.sqliteMaintenance).toMatchObject({ status: 'skipped', reason: 'no_deleted_rows' });
   });
 
   it('does not delete rows within retention window', () => {
@@ -290,5 +343,35 @@ describe('runNightlyCleanup', () => {
 
     const rows = testDb.db.select({ id: schema.jobs.id }).from(schema.jobs).all();
     expect(rows.map(r => r.id)).toEqual(['recent-job']);
+  });
+
+  it('keeps nightly and project log summaries in separate maintenance records', async () => {
+    const now = Date.now() / 1000;
+    const tempDir = mkdtempSync(join(tmpdir(), 'tamtam-retention-cross-'));
+    const oldLogPath = join(tempDir, 'old.ndjson');
+    const newLogPath = join(tempDir, 'new.ndjson');
+    writeFileSync(oldLogPath, 'data');
+    writeFileSync(newLogPath, 'data');
+
+    try {
+      testDb.db.insert(schema.jobs).values(makeJob('proj-old-log', 'proj', now - 120, now - 60, oldLogPath)).run();
+      testDb.db.insert(schema.jobs).values(makeJob('proj-new-log', 'proj', now - 10, now, newLogPath)).run();
+      insertJob('old-row', 'proj', now - 100 * 86400, now - 100 * 86400 + 60);
+
+      const mod = await import('@/lib/jobs/retention');
+      mod.runNightlyCleanup(cfg);
+      mod.pruneProjectLogs('proj', { ...cfg, log_retention_count: 1, log_retention_days: 30 });
+
+      expect(mod.getLatestNightlyRetentionSummary()).toMatchObject({
+        type: 'nightly',
+        rowsDeleted: 1,
+      });
+      expect(mod.getLatestProjectLogRetentionSummary()).toMatchObject({
+        type: 'project_logs',
+        rowsUpdated: 1,
+      });
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
   });
 });

--- a/app/api/monitoring/route.ts
+++ b/app/api/monitoring/route.ts
@@ -1,6 +1,10 @@
 import { NextResponse } from 'next/server'
 import { db, schema } from '@/lib/db'
 import { getSettings } from '@/lib/shared/config'
+import {
+  getLatestNightlyRetentionSummary,
+  getLatestProjectLogRetentionSummary,
+} from '@/lib/jobs/retention'
 
 const PROMETHEUS_URL = process.env.PROMETHEUS_URL ?? 'http://localhost:9090'
 const LOKI_URL = process.env.LOKI_URL ?? 'http://localhost:3100'
@@ -112,9 +116,18 @@ export async function GET(request: Request) {
     suppressedTotal,
     entries: topThrottledNotifications,
   }
+  const retention = {
+    policy: {
+      logRetentionCount: settings.log_retention_count,
+      logRetentionDays: settings.log_retention_days,
+      jobRowRetentionDays: settings.job_row_retention_days,
+    },
+    lastProjectLogCleanup: getLatestProjectLogRetentionSummary(),
+    lastNightlyCleanup: getLatestNightlyRetentionSummary(),
+  }
   const hasIssues =
     (prometheus.status === 'ok' && (prometheus.alerts.length > 0 || downServices.length > 0)) ||
     (loki.status === 'ok' && loki.errors.length > 0)
 
-  return NextResponse.json({ prometheus, loki, notificationThrottle, hasIssues, fetchedAt: now, windowMs, config: { prometheusUrl: PROMETHEUS_URL, lokiUrl: LOKI_URL } })
+  return NextResponse.json({ prometheus, loki, notificationThrottle, retention, hasIssues, fetchedAt: now, windowMs, config: { prometheusUrl: PROMETHEUS_URL, lokiUrl: LOKI_URL } })
 }

--- a/components/monitoring/OverviewTab.tsx
+++ b/components/monitoring/OverviewTab.tsx
@@ -10,6 +10,37 @@ function StatusDot({ ok }: { ok: boolean }) {
   )
 }
 
+function formatBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`
+  return `${(bytes / 1024 / 1024).toFixed(1)} MB`
+}
+
+function formatNightlyCleanupLine(data: MonitoringData['retention']['lastNightlyCleanup']): string {
+  if (!data) return 'No nightly cleanup recorded'
+  const base = `${data.status} · ${data.rowsDeleted} rows`
+  const sqlite = `SQLite ${data.sqliteMaintenance.status}`
+  const error = data.lastError ? ` · ${data.lastError}` : data.sqliteMaintenance.error ? ` · ${data.sqliteMaintenance.error}` : ''
+  return `${base}, ${sqlite}${error}`
+}
+
+function formatProjectLogCleanupLine(data: MonitoringData['retention']['lastProjectLogCleanup']): string {
+  if (!data) return 'No project log prune recorded'
+  const base = `${data.status} · ${data.logFilesDeleted} files, ${formatBytes(data.bytesReclaimed)}`
+  return data.lastError ? `${base} · ${data.lastError}` : base
+}
+
+function getRetentionStatus(retention: MonitoringData['retention']): 'ok' | 'issue' | 'unavailable' {
+  const nightlyCleanup = retention.lastNightlyCleanup
+  const projectLogCleanup = retention.lastProjectLogCleanup
+
+  if (!nightlyCleanup && !projectLogCleanup) return 'unavailable'
+  if (nightlyCleanup?.status === 'failed') return 'issue'
+  if (nightlyCleanup?.sqliteMaintenance.status === 'failed') return 'issue'
+  if (projectLogCleanup?.status === 'failed') return 'issue'
+  return 'ok'
+}
+
 export function OverviewTab({
   data,
   pm2Logs,
@@ -24,6 +55,15 @@ export function OverviewTab({
   const pm2ErrorCount = pm2Logs?.entries.filter(e => e.level === 'error').length ?? 0
   const pm2WarnCount  = pm2Logs?.entries.filter(e => e.level === 'warn').length ?? 0
   const throttle = data.notificationThrottle
+  const retention = data.retention
+  const nightlyCleanup = retention.lastNightlyCleanup
+  const projectLogCleanup = retention.lastProjectLogCleanup
+  const nightlyCleanupTime = nightlyCleanup
+    ? new Date(nightlyCleanup.finishedAt * 1000).toLocaleString()
+    : null
+  const nightlyCleanupTouched = formatNightlyCleanupLine(nightlyCleanup)
+  const projectLogCleanupTouched = formatProjectLogCleanupLine(projectLogCleanup)
+  const cleanupStatus = getRetentionStatus(retention)
 
   const sections = [
     {
@@ -68,6 +108,17 @@ export function OverviewTab({
           : 'No suppressed alerts pending',
       ],
     },
+    {
+      title: 'Retention',
+      status: cleanupStatus,
+      lines: [
+        `Logs ${retention.policy.logRetentionCount} runs / ${retention.policy.logRetentionDays}d`,
+        `Rows ${retention.policy.jobRowRetentionDays}d`,
+        nightlyCleanupTime ? `Nightly ${nightlyCleanupTime}` : nightlyCleanupTouched,
+        nightlyCleanupTime ? nightlyCleanupTouched : null,
+        projectLogCleanupTouched,
+      ].filter(Boolean) as string[],
+    },
   ] as const
 
   const statusIcon = (s: string) =>
@@ -79,7 +130,7 @@ export function OverviewTab({
 
   return (
     <div className="space-y-4">
-      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-3">
+      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-5 gap-3">
         {sections.map(sec => (
           <div key={sec.title} className={`rounded-lg border p-4 flex flex-col gap-2 ${statusCls(sec.status)}`}>
             <div className="flex items-center justify-between gap-2">

--- a/components/monitoring/types.ts
+++ b/components/monitoring/types.ts
@@ -12,6 +12,44 @@ export interface LogLine {
 export type TimeWindow = '5m' | '15m' | '1h'
 export type MonitoringTab = 'overview' | 'agents' | 'logs' | 'infra'
 
+export interface SqliteMaintenanceSummary {
+  status: 'completed' | 'skipped' | 'failed'
+  startedAt: number
+  finishedAt: number
+  activeJobs: number
+  reason?: string
+  checkpointRan: boolean
+  vacuumRan: boolean
+  error?: string
+}
+
+export type RetentionSummary = {
+  type: 'project_logs'
+  project: string
+  status: 'completed' | 'disabled' | 'failed'
+  startedAt: number
+  finishedAt: number
+  rowsScanned: number
+  rowsEligible: number
+  rowsUpdated: number
+  logFilesDeleted: number
+  bytesReclaimed: number
+  skippedRunningRows: number
+  errorCount: number
+  lastError: string | null
+} | {
+  type: 'nightly'
+  status: 'completed' | 'disabled' | 'failed'
+  startedAt: number
+  finishedAt: number
+  rowsScanned: number
+  rowsDeleted: number
+  skippedRunningRows: number
+  errorCount: number
+  lastError: string | null
+  sqliteMaintenance: SqliteMaintenanceSummary
+}
+
 export interface MonitoringData {
   prometheus: {
     status: 'ok' | 'unavailable'
@@ -28,6 +66,15 @@ export interface MonitoringData {
     overrides: Record<string, number>
     suppressedTotal: number
     entries: Array<{ key: string; lastSentAt: number; suppressedCount: number }>
+  }
+  retention: {
+    policy: {
+      logRetentionCount: number
+      logRetentionDays: number
+      jobRowRetentionDays: number
+    }
+    lastProjectLogCleanup: Extract<RetentionSummary, { type: 'project_logs' }> | null
+    lastNightlyCleanup: Extract<RetentionSummary, { type: 'nightly' }> | null
   }
   hasIssues: boolean
   fetchedAt: number

--- a/docs/API.md
+++ b/docs/API.md
@@ -91,7 +91,7 @@ GitHub board cards carry four TEXT custom fields provisioned by `ensureProjectBo
 ## Health / Monitoring / Stats
 
 - `/api/health` — Health check (GET)
-- `/api/monitoring` — Prometheus + Loki status aggregation plus notification throttle state (GET); env: `PROMETHEUS_URL`, `LOKI_URL`
+- `/api/monitoring` — Prometheus + Loki status aggregation plus notification throttle state and separate retention telemetry for the latest nightly row cleanup and per-project log pruning summaries (GET); env: `PROMETHEUS_URL`, `LOKI_URL`
 - `/api/monitoring/pm2-logs` — Tail tamtam PM2 log files (error + out from `~/.pm2/logs/`), last 64 KB; `?limit=` (max 500), `?out=0` to suppress stdout (GET)
 - `/api/stats/usage` — Token usage per project and per agent kind (GET, `?window=24h|7d|30d|all`)
 - `/api/stats/pipeline` — Pipeline health metrics: verdict distribution, recovery-loop stats (`fix` and `fix-push`, attributed by `releaseId` when present and otherwise by the enclosing release window), step durations for the synthetic trigger `agent` step plus `release`, `test`, `review`, `fix`, `commit`, `push`, `pr-wait`, `fix-push`, and `mark-dod` (each with `avg`, `median`, `p95`, `count`, and optional `avgCostUsd` when cost data exists), successful-release duration stats (`mttr.avg`, `mttr.median`, `mttr.p95`, `mttr.count`, optional `mttr.avgCostUsd`), per-project breakdown, and active recovery-budget config snapshot (`maxStepIterations`, `maxFixPushAttempts`, `stepWindowSeconds`; sourced from the same helper as runtime enforcement) (GET, `?window=...`, `?project=`; 60s cache)

--- a/docs/DATABASE.md
+++ b/docs/DATABASE.md
@@ -121,6 +121,18 @@ Persisted dedupe state for outbound webhook throttling.
 
 ---
 
+### `maintenance_status`
+
+Persisted latest-status records for server maintenance tasks. Values are JSON payloads so narrowly scoped maintenance subsystems can evolve their summary shape without a schema change.
+
+| Column | Type | Default | Notes |
+|--------|------|---------|-------|
+| `key` | TEXT | — | PRIMARY KEY; retention uses `retention:project-logs:last` and `retention:nightly:last` |
+| `value` | TEXT | — | JSON summary payload |
+| `updatedAt` | REAL | — | Unix timestamp (seconds) when the summary was written |
+
+---
+
 ### `agents`
 
 Configuration for scheduled automated agents.
@@ -222,6 +234,7 @@ db.select().from(schema.jobs).where(eq(schema.jobs.project, name)).all()
 | Global config (workspace path, Claude bin, verdict rules…) | `settings` | `key` |
 | Project metadata + per-project pipeline flags | `projects` | `name` |
 | Every run / review / fix / push / agent execution | `jobs` | `id` |
+| Latest maintenance telemetry | `maintenance_status` | `key` |
 | Project recommendations from agent/scheduler signals | `recommendations` | `id` |
 | Reusable prompt blocks | `skills` | `id` |
 | Scheduled automation configs | `agents` | `id` |

--- a/docs/SETTINGS.md
+++ b/docs/SETTINGS.md
@@ -161,6 +161,8 @@ All three are read live on each job (not cached), so changing them takes effect 
 | `log_retention_days` | number | `30` | Delete log files older than this many days (per project, evaluated on each run completion). Set to `0` to disable age-based pruning. |
 | `job_row_retention_days` | number | `180` | Nightly cleanup: delete finished `jobs` DB rows older than this many days. Set to `0` to disable. Run rows older than this threshold are permanently removed. |
 
+Retention writes separate latest-summary records to `maintenance_status`: `retention:project-logs:last` for per-project log pruning and `retention:nightly:last` for nightly row cleanup. The nightly record includes row counts, errors, and SQLite checkpoint/vacuum status, so the monitoring API can still report the most recent database maintenance result even after later run completions trigger log pruning. Nightly SQLite maintenance runs `wal_checkpoint(TRUNCATE)` and `VACUUM` after expired rows are deleted, but records a skipped status instead when any job is still active.
+
 ### System
 
 | Key | Type | Default | Effect |

--- a/lib/db/index.ts
+++ b/lib/db/index.ts
@@ -186,6 +186,17 @@ sqlite.exec(`
   );
 `);
 
+// Latest maintenance summaries, including retention cleanup and SQLite
+// checkpoint/vacuum status. Kept as JSON so the monitoring API can render
+// recent maintenance state without parsing process logs.
+sqlite.exec(`
+  CREATE TABLE IF NOT EXISTS maintenance_status (
+    key TEXT PRIMARY KEY,
+    value TEXT NOT NULL,
+    updated_at REAL NOT NULL
+  );
+`);
+
 // Migrate: add token/duration/session columns to jobs if missing
 try {
   sqlite.exec('ALTER TABLE jobs ADD COLUMN duration_ms INTEGER');

--- a/lib/db/migrations/0019_graceful_wendell_rand.sql
+++ b/lib/db/migrations/0019_graceful_wendell_rand.sql
@@ -1,0 +1,5 @@
+CREATE TABLE IF NOT EXISTS `maintenance_status` (
+	`key` text PRIMARY KEY NOT NULL,
+	`value` text NOT NULL,
+	`updated_at` real NOT NULL
+);

--- a/lib/db/migrations/meta/0019_snapshot.json
+++ b/lib/db/migrations/meta/0019_snapshot.json
@@ -1,0 +1,999 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "c1ee8a10-c4cc-4e42-ab1f-10cb13af7948",
+  "prevId": "73c8729e-608b-40a0-b5af-bcbb68fbd992",
+  "tables": {
+    "agents": {
+      "name": "agents",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project": {
+          "name": "project",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "skill_ids": {
+          "name": "skill_ids",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'normal'"
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "schedule": {
+          "name": "schedule",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "runner": {
+          "name": "runner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pm2'"
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "doc_paths": {
+          "name": "doc_paths",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "prerequisite_command": {
+          "name": "prerequisite_command",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "gh_issues_cache": {
+      "name": "gh_issues_cache",
+      "columns": {
+        "project": {
+          "name": "project",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "repo": {
+          "name": "repo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "prs": {
+          "name": "prs",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "issues": {
+          "name": "issues",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "fetched_at": {
+          "name": "fetched_at",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "gh_status": {
+      "name": "gh_status",
+      "columns": {
+        "project": {
+          "name": "project",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "release_tag": {
+          "name": "release_tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ci": {
+          "name": "ci",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ci_failed_url": {
+          "name": "ci_failed_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "head_sha": {
+          "name": "head_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "local_head_sha": {
+          "name": "local_head_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "fetched_at": {
+          "name": "fetched_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "jobs": {
+      "name": "jobs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project": {
+          "name": "project",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pid": {
+          "name": "pid",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "log_path": {
+          "name": "log_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "exit_code": {
+          "name": "exit_code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "seen": {
+          "name": "seen",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cache_read_tokens": {
+          "name": "cache_read_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cache_create_tokens": {
+          "name": "cache_create_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_prompt": {
+          "name": "user_prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "context_meta": {
+          "name": "context_meta",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "parent_job_id": {
+          "name": "parent_job_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "gh_issue_number": {
+          "name": "gh_issue_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "gh_issue_repo": {
+          "name": "gh_issue_repo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "gh_issue_title": {
+          "name": "gh_issue_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "log_pruned": {
+          "name": "log_pruned",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "verdict": {
+          "name": "verdict",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cost_usd": {
+          "name": "cost_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "release_id": {
+          "name": "release_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "aborted_at": {
+          "name": "aborted_at",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "prompt_bytes": {
+          "name": "prompt_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "work_summary": {
+          "name": "work_summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "modified_files": {
+          "name": "modified_files",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "maintenance_status": {
+      "name": "maintenance_status",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "notification_throttle": {
+      "name": "notification_throttle",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_sent_at": {
+          "name": "last_sent_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "suppressed_count": {
+          "name": "suppressed_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "pipeline_locks": {
+      "name": "pipeline_locks",
+      "columns": {
+        "project": {
+          "name": "project",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "locked_by_job_id": {
+          "name": "locked_by_job_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "acquired_at": {
+          "name": "acquired_at",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "projects": {
+      "name": "projects",
+      "columns": {
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "github": {
+          "name": "github",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "priority": {
+          "name": "priority",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "custom_actions": {
+          "name": "custom_actions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "test_command": {
+          "name": "test_command",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tests_disabled": {
+          "name": "tests_disabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "review_disabled": {
+          "name": "review_disabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "test_cron_enabled": {
+          "name": "test_cron_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "test_cron_schedule": {
+          "name": "test_cron_schedule",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "auto_commit_enabled": {
+          "name": "auto_commit_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "auto_push_enabled": {
+          "name": "auto_push_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "auto_pr_merge_enabled": {
+          "name": "auto_pr_merge_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "release_after_run": {
+          "name": "release_after_run",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "issue_auto_branch": {
+          "name": "issue_auto_branch",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": true
+        },
+        "last_push_error": {
+          "name": "last_push_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_push_at": {
+          "name": "last_push_at",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "review_prompt_addendum": {
+          "name": "review_prompt_addendum",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "fix_prompt_addendum": {
+          "name": "fix_prompt_addendum",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "website": {
+          "name": "website",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "qa_url": {
+          "name": "qa_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "archived": {
+          "name": "archived",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "queued_agent_runs": {
+      "name": "queued_agent_runs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "project": {
+          "name": "project",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "agent_name": {
+          "name": "agent_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "triggered_by": {
+          "name": "triggered_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'manual'"
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "enqueued_at": {
+          "name": "enqueued_at",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "queued_agent_runs_project_agent": {
+          "name": "queued_agent_runs_project_agent",
+          "columns": [
+            "project",
+            "agent_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "recommendations": {
+      "name": "recommendations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project": {
+          "name": "project",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_kind": {
+          "name": "source_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "agent_name": {
+          "name": "agent_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "detail": {
+          "name": "detail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'open'"
+        },
+        "payload": {
+          "name": "payload",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "settings": {
+      "name": "settings",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "skills": {
+      "name": "skills",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/lib/db/migrations/meta/_journal.json
+++ b/lib/db/migrations/meta/_journal.json
@@ -134,6 +134,13 @@
       "when": 1778645765813,
       "tag": "0018_green_rattler",
       "breakpoints": true
+    },
+    {
+      "idx": 19,
+      "version": "6",
+      "when": 1778653028243,
+      "tag": "0019_graceful_wendell_rand",
+      "breakpoints": true
     }
   ]
 }

--- a/lib/db/schema.ts
+++ b/lib/db/schema.ts
@@ -152,3 +152,9 @@ export const notificationThrottle = sqliteTable('notification_throttle', {
   lastSentAt: integer('last_sent_at').notNull(),
   suppressedCount: integer('suppressed_count').notNull().default(0),
 });
+
+export const maintenanceStatus = sqliteTable('maintenance_status', {
+  key: text('key').primaryKey(),
+  value: text('value').notNull(),
+  updatedAt: real('updated_at').notNull(),
+});

--- a/lib/jobs/retention.ts
+++ b/lib/jobs/retention.ts
@@ -1,5 +1,5 @@
-import { unlinkSync, existsSync } from 'fs';
-import { lt, and, isNotNull, eq } from 'drizzle-orm';
+import { unlinkSync, existsSync, statSync } from 'fs';
+import { lt, and, isNotNull, eq, isNull, sql } from 'drizzle-orm';
 import { db, schema } from '@/lib/db';
 import { getSettings } from '@/lib/shared/config';
 
@@ -9,22 +9,210 @@ export interface RetentionConfig {
   job_row_retention_days: number;
 }
 
+type CleanupStatus = 'completed' | 'disabled' | 'failed';
+type SqliteMaintenanceStatus = 'completed' | 'skipped' | 'failed';
+
+export interface SqliteMaintenanceSummary {
+  status: SqliteMaintenanceStatus;
+  startedAt: number;
+  finishedAt: number;
+  activeJobs: number;
+  reason?: string;
+  checkpointRan: boolean;
+  vacuumRan: boolean;
+  error?: string;
+}
+
+export interface ProjectLogRetentionSummary {
+  type: 'project_logs';
+  project: string;
+  status: CleanupStatus;
+  startedAt: number;
+  finishedAt: number;
+  rowsScanned: number;
+  rowsEligible: number;
+  rowsUpdated: number;
+  logFilesDeleted: number;
+  bytesReclaimed: number;
+  skippedRunningRows: number;
+  errorCount: number;
+  lastError: string | null;
+}
+
+export interface NightlyRetentionSummary {
+  type: 'nightly';
+  status: CleanupStatus;
+  startedAt: number;
+  finishedAt: number;
+  rowsScanned: number;
+  rowsDeleted: number;
+  skippedRunningRows: number;
+  errorCount: number;
+  lastError: string | null;
+  sqliteMaintenance: SqliteMaintenanceSummary;
+}
+
+export type RetentionSummary = ProjectLogRetentionSummary | NightlyRetentionSummary;
+
+const PROJECT_LOG_RETENTION_STATUS_KEY = 'retention:project-logs:last';
+const NIGHTLY_RETENTION_STATUS_KEY = 'retention:nightly:last';
+
+function nowSeconds(): number {
+  return Date.now() / 1000;
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function getRetentionStatusKey(summary: RetentionSummary): string {
+  return summary.type === 'project_logs'
+    ? PROJECT_LOG_RETENTION_STATUS_KEY
+    : NIGHTLY_RETENTION_STATUS_KEY;
+}
+
+function persistRetentionSummary(summary: RetentionSummary): void {
+  const key = getRetentionStatusKey(summary);
+  try {
+    db.insert(schema.maintenanceStatus)
+      .values({
+        key,
+        value: JSON.stringify(summary),
+        updatedAt: nowSeconds(),
+      })
+      .onConflictDoUpdate({
+        target: schema.maintenanceStatus.key,
+        set: {
+          value: JSON.stringify(summary),
+          updatedAt: nowSeconds(),
+        },
+      })
+      .run();
+  } catch (e) {
+    console.error('[retention] failed to persist cleanup summary:', e);
+  }
+}
+
+function readRetentionSummary<T extends RetentionSummary>(key: string): T | null {
+  try {
+    const row = db.select({ value: schema.maintenanceStatus.value })
+      .from(schema.maintenanceStatus)
+      .where(eq(schema.maintenanceStatus.key, key))
+      .get();
+    if (!row) return null;
+    return JSON.parse(row.value) as T;
+  } catch (e) {
+    console.error('[retention] failed to read cleanup summary:', e);
+    return null;
+  }
+}
+
+export function getLatestProjectLogRetentionSummary(): ProjectLogRetentionSummary | null {
+  return readRetentionSummary<ProjectLogRetentionSummary>(PROJECT_LOG_RETENTION_STATUS_KEY);
+}
+
+export function getLatestNightlyRetentionSummary(): NightlyRetentionSummary | null {
+  return readRetentionSummary<NightlyRetentionSummary>(NIGHTLY_RETENTION_STATUS_KEY);
+}
+
+function runSqliteMaintenance(rowsDeleted: number): SqliteMaintenanceSummary {
+  const startedAt = nowSeconds();
+  const base = {
+    startedAt,
+    finishedAt: startedAt,
+    activeJobs: 0,
+    checkpointRan: false,
+    vacuumRan: false,
+  };
+
+  if (rowsDeleted <= 0) {
+    return {
+      ...base,
+      status: 'skipped',
+      reason: 'no_deleted_rows',
+    };
+  }
+
+  try {
+    const activeJobs = db.select({ id: schema.jobs.id })
+      .from(schema.jobs)
+      .where(isNull(schema.jobs.finishedAt))
+      .all().length;
+
+    if (activeJobs > 0) {
+      return {
+        ...base,
+        finishedAt: nowSeconds(),
+        activeJobs,
+        status: 'skipped',
+        reason: 'active_jobs',
+      };
+    }
+
+    db.run(sql.raw('PRAGMA wal_checkpoint(TRUNCATE)'));
+    db.run(sql.raw('VACUUM'));
+
+    return {
+      ...base,
+      finishedAt: nowSeconds(),
+      status: 'completed',
+      checkpointRan: true,
+      vacuumRan: true,
+    };
+  } catch (e) {
+    return {
+      ...base,
+      finishedAt: nowSeconds(),
+      status: 'failed',
+      reason: 'error',
+      error: errorMessage(e),
+    };
+  }
+}
+
 /**
  * Prune old log files for a project after a run completes.
  * Keeps the last `log_retention_count` finished runs per project, and/or
  * runs newer than `log_retention_days`. Deletes on-disk log files and sets
  * `log_pruned=true` on the DB row; the row itself is preserved for history.
  */
-export function pruneProjectLogs(project: string, cfg?: RetentionConfig): void {
+export function pruneProjectLogs(project: string, cfg?: RetentionConfig): ProjectLogRetentionSummary {
+  const startedAt = nowSeconds();
+  const summary: ProjectLogRetentionSummary = {
+    type: 'project_logs',
+    project,
+    status: 'completed',
+    startedAt,
+    finishedAt: startedAt,
+    rowsScanned: 0,
+    rowsEligible: 0,
+    rowsUpdated: 0,
+    logFilesDeleted: 0,
+    bytesReclaimed: 0,
+    skippedRunningRows: 0,
+    errorCount: 0,
+    lastError: null,
+  };
   const settings = cfg ?? getSettings();
   const { log_retention_count, log_retention_days } = settings;
 
   // Treat 0 (or negative) as "disabled" for either dimension.
   const countEnabled = log_retention_count > 0;
   const ageEnabled = log_retention_days > 0;
-  if (!countEnabled && !ageEnabled) return;
+  if (!countEnabled && !ageEnabled) {
+    summary.status = 'disabled';
+    summary.finishedAt = nowSeconds();
+    persistRetentionSummary(summary);
+    return summary;
+  }
 
-  const cutoffTs = ageEnabled ? Date.now() / 1000 - log_retention_days * 86400 : -Infinity;
+  const cutoffTs = ageEnabled ? nowSeconds() - log_retention_days * 86400 : -Infinity;
+
+  const skippedRunningRows = db.select({ id: schema.jobs.id })
+    .from(schema.jobs)
+    .where(and(eq(schema.jobs.project, project), isNull(schema.jobs.finishedAt)))
+    .all().length;
+  summary.skippedRunningRows = skippedRunningRows;
 
   // Get all finished jobs for this project, newest first.
   const rows = db
@@ -33,6 +221,7 @@ export function pruneProjectLogs(project: string, cfg?: RetentionConfig): void {
     .where(and(eq(schema.jobs.project, project), isNotNull(schema.jobs.finishedAt)))
     .all()
     .sort((a, b) => b.startedAt - a.startedAt);
+  summary.rowsScanned = rows.length;
 
   const toPrune: string[] = [];
   for (let i = 0; i < rows.length; i++) {
@@ -42,20 +231,38 @@ export function pruneProjectLogs(project: string, cfg?: RetentionConfig): void {
     const overAge = ageEnabled && row.startedAt < cutoffTs;
     if (overCount || overAge) toPrune.push(row.id);
   }
+  summary.rowsEligible = toPrune.length;
 
   for (const id of toPrune) {
     const row = rows.find(r => r.id === id);
     if (!row) continue;
     if (row.logPath && existsSync(row.logPath)) {
-      try { unlinkSync(row.logPath); } catch {}
+      try {
+        const size = statSync(row.logPath).size;
+        unlinkSync(row.logPath);
+        summary.logFilesDeleted += 1;
+        summary.bytesReclaimed += size;
+      } catch (e) {
+        summary.errorCount += 1;
+        summary.lastError = errorMessage(e);
+      }
     }
     try {
       db.update(schema.jobs)
         .set({ logPruned: true })
         .where(eq(schema.jobs.id, id))
         .run();
-    } catch {}
+      summary.rowsUpdated += 1;
+    } catch (e) {
+      summary.errorCount += 1;
+      summary.lastError = errorMessage(e);
+    }
   }
+
+  summary.status = summary.errorCount > 0 ? 'failed' : 'completed';
+  summary.finishedAt = nowSeconds();
+  persistRetentionSummary(summary);
+  return summary;
 }
 
 /**
@@ -63,20 +270,66 @@ export function pruneProjectLogs(project: string, cfg?: RetentionConfig): void {
  * Only removes finished rows (finishedAt IS NOT NULL) to avoid touching
  * running jobs.
  */
-export function runNightlyCleanup(cfg?: RetentionConfig): void {
+export function runNightlyCleanup(cfg?: RetentionConfig): NightlyRetentionSummary {
+  const startedAt = nowSeconds();
+  const summary: NightlyRetentionSummary = {
+    type: 'nightly',
+    status: 'completed',
+    startedAt,
+    finishedAt: startedAt,
+    rowsScanned: 0,
+    rowsDeleted: 0,
+    skippedRunningRows: 0,
+    errorCount: 0,
+    lastError: null,
+    sqliteMaintenance: {
+      status: 'skipped',
+      startedAt,
+      finishedAt: startedAt,
+      activeJobs: 0,
+      reason: 'not_started',
+      checkpointRan: false,
+      vacuumRan: false,
+    },
+  };
   const settings = cfg ?? getSettings();
   const { job_row_retention_days } = settings;
 
   // 0 (or negative) disables row deletion entirely.
-  if (job_row_retention_days <= 0) return;
+  if (job_row_retention_days <= 0) {
+    summary.status = 'disabled';
+    summary.sqliteMaintenance = runSqliteMaintenance(0);
+    summary.finishedAt = nowSeconds();
+    persistRetentionSummary(summary);
+    return summary;
+  }
 
-  const cutoffTs = Date.now() / 1000 - job_row_retention_days * 86400;
+  const cutoffTs = nowSeconds() - job_row_retention_days * 86400;
 
   try {
-    db.delete(schema.jobs)
+    const oldFinishedRows = db.select({ id: schema.jobs.id })
+      .from(schema.jobs)
+      .where(and(isNotNull(schema.jobs.finishedAt), lt(schema.jobs.startedAt, cutoffTs)))
+      .all();
+    summary.rowsScanned = oldFinishedRows.length;
+    summary.skippedRunningRows = db.select({ id: schema.jobs.id })
+      .from(schema.jobs)
+      .where(and(isNull(schema.jobs.finishedAt), lt(schema.jobs.startedAt, cutoffTs)))
+      .all().length;
+
+    const result = db.delete(schema.jobs)
       .where(and(isNotNull(schema.jobs.finishedAt), lt(schema.jobs.startedAt, cutoffTs)))
       .run();
+    summary.rowsDeleted = result.changes ?? oldFinishedRows.length;
+    summary.sqliteMaintenance = runSqliteMaintenance(summary.rowsDeleted);
   } catch (e) {
+    summary.status = 'failed';
+    summary.errorCount += 1;
+    summary.lastError = errorMessage(e);
     console.error('[retention] nightly cleanup failed:', e);
   }
+
+  summary.finishedAt = nowSeconds();
+  persistRetentionSummary(summary);
+  return summary;
 }


### PR DESCRIPTION
Closes #28

Implemented retention cleanup telemetry and monitoring visibility for issue #28.

---
Implemented via TamTam from issue [#28](https://github.com/3h4x/tamtam/issues/28).