### PR TITLE
fix: Improve semantic retrieval quality so CLI runs get better project context

### DIFF
--- a/__tests__/api/agent-run.test.ts
+++ b/__tests__/api/agent-run.test.ts
@@ -79,7 +79,7 @@ describe('POST /api/agents/{agentId}/run', () => {
   let getPendingReleaseMock: ReturnType<typeof vi.fn>;
   let drainPendingReleaseMock: ReturnType<typeof vi.fn>;
   let isProjectPausedMock: ReturnType<typeof vi.fn>;
-  let retrieveAgentContextMock: ReturnType<typeof vi.fn>;
+  let retrieveAgentContextDetailedMock: ReturnType<typeof vi.fn>;
   let isSqliteVecAvailableMock: ReturnType<typeof vi.fn>;
   let tempSkillsDir: string;
   let logDirMock: string;
@@ -155,7 +155,18 @@ describe('POST /api/agents/{agentId}/run', () => {
     getPendingReleaseMock = vi.fn().mockReturnValue(false);
     drainPendingReleaseMock = vi.fn().mockResolvedValue(undefined);
     isProjectPausedMock = vi.fn().mockReturnValue(false);
-    retrieveAgentContextMock = vi.fn().mockResolvedValue('## Retrieved Context\ncached context');
+    retrieveAgentContextDetailedMock = vi.fn().mockResolvedValue({
+      block: '## Retrieved Context\ncached context',
+      diagnostics: {
+        status: 'ok',
+        reason: 'results',
+        corpusChunkCount: 3,
+        retrievedCount: 1,
+        acceptedCount: 1,
+        topScore: 0.9,
+        scoreThreshold: 0.8,
+      },
+    });
     isSqliteVecAvailableMock = vi.fn().mockReturnValue(true);
     settingsMock = {
       workspace_path: '',
@@ -247,7 +258,7 @@ describe('POST /api/agents/{agentId}/run', () => {
       checkCliStartGate: checkCliStartGateMock,
     }));
     vi.doMock('@/lib/agents/retrieval/retriever', () => ({
-      retrieveAgentContext: retrieveAgentContextMock,
+      retrieveAgentContextDetailed: retrieveAgentContextDetailedMock,
     }));
     vi.doMock('@/lib/git/dirty-worktree', () => ({
       getDirtyFileCount: vi.fn().mockResolvedValue(0),
@@ -293,7 +304,7 @@ describe('POST /api/agents/{agentId}/run', () => {
 
     expect(res.status).toBe(200);
     expect(body.status).toBe('started');
-    expect(retrieveAgentContextMock).not.toHaveBeenCalled();
+    expect(retrieveAgentContextDetailedMock).not.toHaveBeenCalled();
     expect(startJobMock).toHaveBeenCalledOnce();
   });
 

--- a/__tests__/api/retrieval-reindex.test.ts
+++ b/__tests__/api/retrieval-reindex.test.ts
@@ -1,8 +1,39 @@
+import { createHash } from 'crypto';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 const mockUpsert = vi.hoisted(() => vi.fn());
-const mockListProjectDocuments = vi.hoisted(() => vi.fn().mockReturnValue(['/tmp/workspace/myproject/README.md']));
+const mockDeleteSource = vi.hoisted(() => vi.fn());
+const mockExistingRecords = vi.hoisted<
+  Array<{
+    id: string;
+    project: string;
+    sourceKind: string;
+    sourceId: string;
+    chunkCount: number;
+    contentHash: string;
+    indexedAt: number;
+  }>
+>(() => []);
+const mockInsertRun = vi.hoisted(() => vi.fn());
 const mockIsSqliteVecAvailable = vi.hoisted(() => vi.fn().mockReturnValue(true));
+const mockCollectProjectRetrievalSources = vi.hoisted(() => vi.fn().mockReturnValue([
+  {
+    recordId: 'myproject:project_doc:README.md',
+    sourceKind: 'project_doc',
+    sourceId: 'README.md',
+    text: '# README\n\nProject docs here.',
+    metadata: { filePath: 'README.md' },
+    updatedAt: 100,
+  },
+  {
+    recordId: 'myproject:skill:skill-1',
+    sourceKind: 'skill',
+    sourceId: 'skill-1',
+    text: '# Skill\n\nUse focused tests first.',
+    metadata: { skillTitle: 'Skill 1' },
+    updatedAt: 200,
+  },
+]));
 
 vi.mock('@/lib/shared/config', () => ({
   getSettings: vi.fn().mockReturnValue({
@@ -20,12 +51,14 @@ vi.mock('@/lib/agents/retrieval/sqlite-vec-backend', () => ({
   SqliteVecBackend: vi.fn().mockImplementation(function(this: {
     upsertChunks: typeof mockUpsert;
     search: ReturnType<typeof vi.fn>;
+    countProjectChunks: ReturnType<typeof vi.fn>;
     deleteSource: ReturnType<typeof vi.fn>;
     deleteProject: ReturnType<typeof vi.fn>;
   }) {
     this.upsertChunks = mockUpsert;
     this.search = vi.fn();
-    this.deleteSource = vi.fn();
+    this.countProjectChunks = vi.fn().mockReturnValue(0);
+    this.deleteSource = mockDeleteSource;
     this.deleteProject = vi.fn();
   }),
 }));
@@ -34,21 +67,30 @@ vi.mock('@/lib/db', () => ({
   sqlite: {},
   db: {
     select: vi.fn().mockReturnValue({
-      from: vi.fn().mockReturnValue({ where: vi.fn().mockReturnValue({ get: vi.fn().mockReturnValue(null) }) }),
+      from: vi.fn().mockReturnValue({
+        where: vi.fn().mockReturnValue({
+          all: vi.fn(() => mockExistingRecords),
+        }),
+      }),
     }),
     insert: vi.fn().mockReturnValue({
-      values: vi.fn().mockReturnValue({ onConflictDoUpdate: vi.fn().mockReturnValue({ run: vi.fn() }) }),
+      values: vi.fn().mockReturnValue({
+        onConflictDoUpdate: vi.fn().mockReturnValue({ run: mockInsertRun }),
+      }),
+    }),
+    delete: vi.fn().mockReturnValue({
+      where: vi.fn().mockReturnValue({ run: vi.fn() }),
     }),
   },
-  schema: { retrievalRecords: {} },
+  schema: { retrievalRecords: { id: 'id', project: 'project', sourceKind: 'source_kind' } },
 }));
 
 vi.mock('@/lib/shared/project-data', () => ({
   resolveProjectPath: vi.fn().mockReturnValue('/tmp/workspace/myproject'),
 }));
 
-vi.mock('@/lib/shared/project-documents', () => ({
-  listProjectDocuments: mockListProjectDocuments,
+vi.mock('@/lib/agents/retrieval/project-corpus', () => ({
+  collectProjectRetrievalSources: mockCollectProjectRetrievalSources,
 }));
 vi.mock('@/lib/db/sqlite-vec', () => ({
   isSqliteVecAvailable: mockIsSqliteVecAvailable,
@@ -56,16 +98,13 @@ vi.mock('@/lib/db/sqlite-vec', () => ({
     'Retrieval is unavailable: sqlite-vec is not installed in this environment'
   ),
 }));
-vi.mock('fs', async (orig) => ({
-  ...(await orig<typeof import('fs')>()),
-  existsSync: vi.fn().mockReturnValue(true),
-  readFileSync: vi.fn().mockReturnValue('# README\n\nProject docs here.'),
-}));
-
 describe('POST /api/projects/[schedId]/retrieval/reindex', () => {
   beforeEach(() => {
     mockUpsert.mockClear();
-    mockListProjectDocuments.mockClear();
+    mockDeleteSource.mockClear();
+    mockExistingRecords.length = 0;
+    mockInsertRun.mockClear();
+    mockCollectProjectRetrievalSources.mockClear();
     mockIsSqliteVecAvailable.mockReturnValue(true);
   });
 
@@ -82,8 +121,11 @@ describe('POST /api/projects/[schedId]/retrieval/reindex', () => {
     const { POST } = await import('@/app/api/projects/[schedId]/retrieval/reindex/route');
     const res = await POST(new Request('http://x', { method: 'POST' }), { params: Promise.resolve({ schedId: 'myproject' }) });
     expect(res.status).toBe(200);
-    const body = await res.json() as { chunks: number };
+    const body = await res.json() as { chunks: number; indexedSources: number; diagnostics: { sourceCounts: Record<string, number> } };
     expect(typeof body.chunks).toBe('number');
+    expect(body.indexedSources).toBe(2);
+    expect(body.diagnostics.sourceCounts.project_doc).toBe(1);
+    expect(body.diagnostics.sourceCounts.skill).toBe(1);
   });
 
   it('returns 503 when sqlite-vec is unavailable', async () => {
@@ -93,7 +135,75 @@ describe('POST /api/projects/[schedId]/retrieval/reindex', () => {
     expect(res.status).toBe(503);
     const body = await res.json() as { code: string };
     expect(body.code).toBe('sqlite_vec_unavailable');
-    expect(mockListProjectDocuments).not.toHaveBeenCalled();
+    expect(mockCollectProjectRetrievalSources).not.toHaveBeenCalled();
     expect(mockUpsert).not.toHaveBeenCalled();
+  });
+
+  it('refreshes indexedAt for timestamp-only stale sources without re-embedding', async () => {
+    const text = '# README\n\nProject docs here.';
+    const contentHash = createHash('sha256').update(text).digest('hex');
+    mockCollectProjectRetrievalSources.mockReturnValueOnce([
+      {
+        recordId: 'myproject:project_doc:README.md',
+        sourceKind: 'project_doc',
+        sourceId: 'README.md',
+        text,
+        metadata: { filePath: 'README.md' },
+        updatedAt: 200,
+      },
+    ]);
+    mockExistingRecords.push({
+      id: 'myproject:project_doc:README.md',
+      project: 'myproject',
+      sourceKind: 'project_doc',
+      sourceId: 'README.md',
+      chunkCount: 3,
+      contentHash,
+      indexedAt: 100,
+    });
+
+    const { POST } = await import('@/app/api/projects/[schedId]/retrieval/reindex/route');
+    const res = await POST(new Request('http://x', { method: 'POST' }), { params: Promise.resolve({ schedId: 'myproject' }) });
+
+    expect(res.status).toBe(200);
+    const body = await res.json() as {
+      skippedSources: number;
+      diagnostics: { staleSourcesBeforeReindex: number };
+    };
+    expect(body.skippedSources).toBe(1);
+    expect(body.diagnostics.staleSourcesBeforeReindex).toBe(1);
+    expect(mockUpsert).not.toHaveBeenCalled();
+    expect(mockDeleteSource).not.toHaveBeenCalled();
+    expect(mockInsertRun).toHaveBeenCalledOnce();
+  });
+
+  it('purges stale file-agent project-doc rows that are no longer in the trusted corpus', async () => {
+    mockCollectProjectRetrievalSources.mockReturnValueOnce([
+      {
+        recordId: 'myproject:project_doc:README.md',
+        sourceKind: 'project_doc',
+        sourceId: 'README.md',
+        text: '# README\n\nProject docs here.',
+        metadata: { filePath: 'README.md' },
+        updatedAt: 100,
+      },
+    ]);
+    mockExistingRecords.push({
+      id: 'myproject:project_doc:.tamtam/agents/qa.md',
+      project: 'myproject',
+      sourceKind: 'project_doc',
+      sourceId: '.tamtam/agents/qa.md',
+      chunkCount: 2,
+      contentHash: 'stale',
+      indexedAt: 100,
+    });
+
+    const { POST } = await import('@/app/api/projects/[schedId]/retrieval/reindex/route');
+    const res = await POST(new Request('http://x', { method: 'POST' }), { params: Promise.resolve({ schedId: 'myproject' }) });
+
+    expect(res.status).toBe(200);
+    expect(mockDeleteSource).toHaveBeenCalledWith('myproject', 'project_doc', '.tamtam/agents/qa.md');
+    const body = await res.json() as { diagnostics: { staleSourcesBeforeReindex: number } };
+    expect(body.diagnostics.staleSourcesBeforeReindex).toBe(1);
   });
 });

--- a/__tests__/lib/retrieval/chunker.test.ts
+++ b/__tests__/lib/retrieval/chunker.test.ts
@@ -16,27 +16,27 @@ describe('chunkText', () => {
     const text = 'a'.repeat(CHUNK_SIZE + CHUNK_OVERLAP + 100);
     const chunks = chunkText(text);
     expect(chunks.length).toBeGreaterThan(1);
-    for (let i = 0; i < chunks.length - 1; i++) {
-      expect(chunks[i].length).toBe(CHUNK_SIZE);
-    }
+    expect(chunks.every((chunk) => chunk.length <= CHUNK_SIZE)).toBe(true);
   });
 
-  it('adjacent chunks share CHUNK_OVERLAP characters', () => {
-    const text = 'x'.repeat(CHUNK_SIZE * 2);
+  it('keeps markdown headings attached to the following section when possible', () => {
+    const text = ['# Alpha', 'first section', '', '# Beta', 'second section'].join('\n');
     const chunks = chunkText(text);
-    expect(chunks.length).toBeGreaterThanOrEqual(2);
-    const tail = chunks[0].slice(-CHUNK_OVERLAP);
-    const head = chunks[1].slice(0, CHUNK_OVERLAP);
-    expect(tail).toBe(head);
+    expect(chunks).toEqual(['# Alpha\nfirst section\n\n# Beta\nsecond section']);
   });
 
-  it('covers entire input with no gaps', () => {
-    const text = 'abc'.repeat(1000);
+  it('splits oversized sections while preserving their heading', () => {
+    const text = `# Big Section\n\n${'x'.repeat(CHUNK_SIZE + 300)}`;
     const chunks = chunkText(text);
-    let reconstructed = chunks[0];
-    for (let i = 1; i < chunks.length; i++) {
-      reconstructed += chunks[i].slice(CHUNK_OVERLAP);
-    }
-    expect(reconstructed).toBe(text);
+    expect(chunks.length).toBeGreaterThan(1);
+    expect(chunks.every((chunk) => chunk.startsWith('# Big Section'))).toBe(true);
+  });
+
+  it('prefers paragraph boundaries for medium-sized markdown sections', () => {
+    const paragraph = 'word '.repeat(120);
+    const text = ['# One', paragraph, '', '# Two', paragraph, '', '# Three', paragraph].join('\n');
+    const chunks = chunkText(text);
+    expect(chunks.length).toBeGreaterThan(1);
+    expect(chunks.every((chunk) => chunk.includes('#'))).toBe(true);
   });
 });

--- a/__tests__/lib/retrieval/ingestion.test.ts
+++ b/__tests__/lib/retrieval/ingestion.test.ts
@@ -7,6 +7,7 @@ vi.mock('@/lib/agents/retrieval/ollama-embedder', () => ({ embedText: mockEmbed 
 const mockBackend = {
   upsertChunks: vi.fn(),
   search: vi.fn(),
+  countProjectChunks: vi.fn().mockReturnValue(0),
   deleteSource: vi.fn(),
   deleteProject: vi.fn(),
 };
@@ -121,5 +122,27 @@ describe('ingestAgentRun', () => {
       skipped: false,
       stored: false,
     }));
+  });
+
+  it('deletes an existing source before storing replacement chunks', async () => {
+    const { ingestSourceText } = await import('@/lib/agents/retrieval/ingestion');
+
+    await ingestSourceText({
+      backend: mockBackend,
+      project: 'myproject',
+      sourceKind: 'project_doc',
+      sourceId: 'README.md',
+      text: '# README\n\nUpdated docs',
+      metadata: { filePath: 'README.md' },
+      ollamaUrl: 'http://localhost:11434',
+      embeddingModel: 'nomic-embed-text',
+      existingHash: 'old-hash',
+    });
+
+    expect(mockBackend.deleteSource).toHaveBeenCalledWith('myproject', 'project_doc', 'README.md');
+    expect(mockBackend.upsertChunks).toHaveBeenCalledOnce();
+    expect(mockBackend.deleteSource.mock.invocationCallOrder[0]).toBeLessThan(
+      mockBackend.upsertChunks.mock.invocationCallOrder[0]
+    );
   });
 });

--- a/__tests__/lib/retrieval/project-corpus.test.ts
+++ b/__tests__/lib/retrieval/project-corpus.test.ts
@@ -1,0 +1,197 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import Database from 'better-sqlite3';
+import { drizzle } from 'drizzle-orm/better-sqlite3';
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import * as schema from '@/lib/db/schema';
+
+function createTestDb() {
+  const sqlite = new Database(':memory:');
+  sqlite.pragma('journal_mode = WAL');
+  sqlite.exec(`
+    CREATE TABLE IF NOT EXISTS settings (
+      key TEXT PRIMARY KEY,
+      value TEXT NOT NULL
+    );
+    CREATE TABLE IF NOT EXISTS skills (
+      id TEXT PRIMARY KEY,
+      name TEXT NOT NULL,
+      description TEXT NOT NULL DEFAULT '',
+      content TEXT NOT NULL DEFAULT '',
+      created_at REAL NOT NULL,
+      updated_at REAL NOT NULL
+    );
+    CREATE TABLE IF NOT EXISTS agents (
+      id TEXT PRIMARY KEY,
+      name TEXT NOT NULL,
+      project TEXT NOT NULL,
+      skill_ids TEXT NOT NULL DEFAULT '[]',
+      model TEXT NOT NULL DEFAULT 'normal',
+      prompt TEXT NOT NULL DEFAULT '',
+      schedule TEXT,
+      runner TEXT NOT NULL DEFAULT 'pm2',
+      enabled INTEGER NOT NULL DEFAULT 1,
+      doc_paths TEXT NOT NULL DEFAULT '[]',
+      provider TEXT,
+      prerequisite_command TEXT,
+      created_at REAL NOT NULL,
+      updated_at REAL NOT NULL
+    );
+    CREATE TABLE IF NOT EXISTS projects (
+      name TEXT PRIMARY KEY,
+      path TEXT NOT NULL,
+      enabled INTEGER DEFAULT 0,
+      github TEXT,
+      priority TEXT,
+      custom_actions TEXT,
+      test_command TEXT,
+      tests_disabled INTEGER DEFAULT 0,
+      review_disabled INTEGER DEFAULT 0,
+      test_cron_enabled INTEGER DEFAULT 0,
+      test_cron_schedule TEXT,
+      auto_commit_enabled INTEGER DEFAULT 0,
+      auto_push_enabled INTEGER DEFAULT 0,
+      auto_pr_merge_enabled INTEGER DEFAULT 0,
+      release_after_run INTEGER DEFAULT 0,
+      issue_auto_branch INTEGER DEFAULT 1,
+      last_push_error TEXT,
+      last_push_at REAL,
+      review_prompt_addendum TEXT,
+      fix_prompt_addendum TEXT,
+      website TEXT,
+      qa_url TEXT,
+      archived INTEGER NOT NULL DEFAULT 0,
+      paused INTEGER NOT NULL DEFAULT 0
+    );
+  `);
+  return { sqlite, db: drizzle(sqlite, { schema }) };
+}
+
+describe('collectProjectRetrievalSources', () => {
+  let projectPath: string;
+  let testDb: ReturnType<typeof createTestDb>;
+  let listProjectDocumentsMock: ReturnType<typeof vi.fn>;
+  let getBranchContextMock: ReturnType<typeof vi.fn>;
+  let gitLsTreeSyncMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    vi.resetModules();
+    projectPath = mkdtempSync(join(tmpdir(), 'tamtam-project-corpus-'));
+    mkdirSync(join(projectPath, '.tamtam', 'agents'), { recursive: true });
+    testDb = createTestDb();
+    listProjectDocumentsMock = vi.fn().mockReturnValue([]);
+    getBranchContextMock = vi.fn().mockReturnValue({ isDefaultBranch: true, defaultBranch: 'master' });
+    gitLsTreeSyncMock = vi.fn().mockReturnValue([]);
+  });
+
+  afterEach(() => {
+    testDb.sqlite.close();
+    rmSync(projectPath, { recursive: true, force: true });
+    vi.resetModules();
+  });
+
+  async function importSubject() {
+    vi.doMock('@/lib/db', () => ({ db: testDb.db, schema }));
+    vi.doMock('@/lib/shared/project-documents', () => ({
+      listProjectDocuments: listProjectDocumentsMock,
+    }));
+    vi.doMock('@/lib/git/git-branch', () => ({
+      getBranchContext: getBranchContextMock,
+      gitLsTreeSync: gitLsTreeSyncMock,
+      gitShowSync: vi.fn(),
+    }));
+    return import('@/lib/agents/retrieval/project-corpus');
+  }
+
+  it('indexes DB skills referenced by file agents after file-agent overrides are applied', async () => {
+    const now = 1_700_000_000;
+    writeFileSync(
+      join(projectPath, '.tamtam', 'agents', 'qa.md'),
+      `---\nskillIds: ["skill-from-file"]\n---\n\nRun checks.\n`
+    );
+    testDb.db.insert(schema.skills).values([
+      { id: 'skill-from-file', name: 'File Skill', description: '', content: 'from file', createdAt: now, updatedAt: now },
+      { id: 'skill-from-override', name: 'Override Skill', description: '', content: 'from override', createdAt: now, updatedAt: now },
+    ]).run();
+    testDb.db.insert(schema.settings).values({
+      key: 'agent_override:myproject:qa',
+      value: JSON.stringify({ skillIds: ['skill-from-override'] }),
+    }).run();
+    testDb.db.insert(schema.projects).values({ name: 'myproject', path: projectPath, enabled: true }).run();
+
+    const { collectProjectRetrievalSources } = await importSubject();
+    const sources = collectProjectRetrievalSources('myproject', projectPath);
+
+    expect(sources.filter((source) => source.sourceKind === 'skill').map((source) => source.sourceId)).toEqual([
+      'skill-from-override',
+    ]);
+  });
+
+  it('excludes file-agent skills when a DB agent with the same name takes precedence', async () => {
+    const now = 1_700_000_000;
+    writeFileSync(
+      join(projectPath, '.tamtam', 'agents', 'qa.md'),
+      `---\nskillIds: ["skill-from-file"]\n---\n\nRun checks.\n`
+    );
+    testDb.db.insert(schema.skills).values([
+      { id: 'skill-from-db', name: 'DB Skill', description: '', content: 'from db', createdAt: now, updatedAt: now },
+      { id: 'skill-from-file', name: 'File Skill', description: '', content: 'from file', createdAt: now, updatedAt: now },
+      { id: 'skill-from-other-file-agent', name: 'Other File Skill', description: '', content: 'from other file agent', createdAt: now, updatedAt: now },
+    ]).run();
+    testDb.db.insert(schema.agents).values({
+      id: 'agent-1',
+      name: 'qa',
+      project: 'myproject',
+      skillIds: JSON.stringify(['skill-from-db']),
+      model: 'normal',
+      prompt: '',
+      schedule: null,
+      runner: 'pm2',
+      enabled: true,
+      docPaths: JSON.stringify([]),
+      provider: null,
+      prerequisiteCommand: null,
+      createdAt: now,
+      updatedAt: now,
+    }).run();
+    writeFileSync(
+      join(projectPath, '.tamtam', 'agents', 'docs.md'),
+      `---\nskillIds: ["skill-from-other-file-agent"]\n---\n\nSync docs.\n`
+    );
+    testDb.db.insert(schema.projects).values({ name: 'myproject', path: projectPath, enabled: true }).run();
+
+    const { collectProjectRetrievalSources } = await importSubject();
+    const sources = collectProjectRetrievalSources('myproject', projectPath);
+
+    expect(sources.filter((source) => source.sourceKind === 'skill').map((source) => source.sourceId).sort()).toEqual([
+      'skill-from-db',
+      'skill-from-other-file-agent',
+    ]);
+  });
+
+  it('does not index working-tree file-agent markdown as project docs on non-default branches', async () => {
+    const readmePath = join(projectPath, 'README.md');
+    const fileAgentPath = join(projectPath, '.tamtam', 'agents', 'qa.md');
+    writeFileSync(readmePath, '# README\n\nTrusted docs.\n');
+    writeFileSync(fileAgentPath, 'working tree agent prompt');
+    listProjectDocumentsMock.mockImplementation((_projectPath: string, opts?: { includeAgentDocs?: boolean }) => {
+      if (opts?.includeAgentDocs === false) {
+        return [readmePath];
+      }
+      return [readmePath, fileAgentPath];
+    });
+    getBranchContextMock.mockReturnValue({ isDefaultBranch: false, defaultBranch: 'master' });
+    testDb.db.insert(schema.projects).values({ name: 'myproject', path: projectPath, enabled: true }).run();
+
+    const { collectProjectRetrievalSources } = await importSubject();
+    const sources = collectProjectRetrievalSources('myproject', projectPath);
+
+    expect(listProjectDocumentsMock).toHaveBeenCalledWith(projectPath, { includeAgentDocs: false });
+    expect(
+      sources
+        .filter((source) => source.sourceKind === 'project_doc')
+        .map((source) => source.sourceId)
+    ).toEqual(['README.md']);
+  });
+});

--- a/__tests__/lib/retrieval/retriever.test.ts
+++ b/__tests__/lib/retrieval/retriever.test.ts
@@ -7,12 +7,13 @@ vi.mock('@/lib/agents/retrieval/ollama-embedder', () => ({ embedText: mockEmbed 
 const mockSearch = vi.fn();
 const mockBackend = {
   search: mockSearch,
+  countProjectChunks: vi.fn().mockReturnValue(3),
   upsertChunks: vi.fn(),
   deleteSource: vi.fn(),
   deleteProject: vi.fn(),
 };
 
-import { buildRetrievedContextBlock, retrieveAgentContext } from '@/lib/agents/retrieval/retriever';
+import { buildRetrievedContextBlock, retrieveAgentContext, retrieveAgentContextDetailed } from '@/lib/agents/retrieval/retriever';
 
 describe('buildRetrievedContextBlock', () => {
   it('returns null for empty results', () => {
@@ -50,7 +51,12 @@ describe('buildRetrievedContextBlock', () => {
 });
 
 describe('retrieveAgentContext', () => {
-  beforeEach(() => { mockSearch.mockReset(); mockEmbed.mockResolvedValue(Array(768).fill(0.1)); });
+  beforeEach(() => {
+    mockSearch.mockReset();
+    mockEmbed.mockClear();
+    mockEmbed.mockResolvedValue(Array(768).fill(0.1));
+    mockBackend.countProjectChunks.mockReturnValue(3);
+  });
 
   it('returns null when all results are below threshold', async () => {
     mockSearch.mockReturnValue([
@@ -97,5 +103,43 @@ describe('retrieveAgentContext', () => {
       embeddingModel: 'nomic-embed-text',
     });
     expect(result).toBeNull();
+  });
+
+  it('returns empty-corpus diagnostics without embedding when no chunks are indexed', async () => {
+    mockBackend.countProjectChunks.mockReturnValue(0);
+
+    const result = await retrieveAgentContextDetailed({
+      backend: mockBackend,
+      project: 'myproject',
+      taskPrompt: 'review',
+      limit: 5,
+      scoreThreshold: 0.8,
+      ollamaUrl: 'http://localhost:11434',
+      embeddingModel: 'nomic-embed-text',
+    });
+
+    expect(result.block).toBeNull();
+    expect(result.diagnostics.reason).toBe('empty_corpus');
+    expect(mockEmbed).not.toHaveBeenCalled();
+  });
+
+  it('reports below-threshold diagnostics when search returns only weak matches', async () => {
+    mockSearch.mockReturnValue([
+      { text: 'irrelevant', sourceKind: 'agent_run', sourceId: 'j1', score: 0.4, metadata: {} },
+    ]);
+
+    const result = await retrieveAgentContextDetailed({
+      backend: mockBackend,
+      project: 'myproject',
+      taskPrompt: 'review',
+      limit: 5,
+      scoreThreshold: 0.8,
+      ollamaUrl: 'http://localhost:11434',
+      embeddingModel: 'nomic-embed-text',
+    });
+
+    expect(result.block).toBeNull();
+    expect(result.diagnostics.reason).toBe('below_threshold');
+    expect(result.diagnostics.topScore).toBe(0.4);
   });
 });

--- a/__tests__/lib/retrieval/sqlite-vec-backend.test.ts
+++ b/__tests__/lib/retrieval/sqlite-vec-backend.test.ts
@@ -130,4 +130,43 @@ describeIfSqliteVec('SqliteVecBackend', () => {
     });
     expect(results.every(r => r.sourceKind === 'agent_run')).toBe(true);
   });
+
+  it('counts chunks for a project and optional source filters', () => {
+    backend.upsertChunks([
+      makeChunk({ chunkId: 'agent_run:j1:0', sourceKind: 'agent_run' }),
+      makeChunk({ chunkId: 'project_doc:readme:0', sourceKind: 'project_doc', sourceId: 'README.md' }),
+      makeChunk({ chunkId: 'project_doc:readme:1', sourceKind: 'project_doc', sourceId: 'README.md', chunkIndex: 1 }),
+      makeChunk({ chunkId: 'agent_run:other:0', project: 'other' }),
+    ]);
+
+    expect(backend.countProjectChunks('myproject')).toBe(3);
+    expect(backend.countProjectChunks('myproject', ['project_doc'])).toBe(2);
+    expect(backend.countProjectChunks('other')).toBe(1);
+  });
+
+  it('removes trailing stale chunks when a source is replaced with fewer chunks', () => {
+    backend.upsertChunks([
+      makeChunk({ chunkId: 'project_doc:README.md:0', sourceKind: 'project_doc', sourceId: 'README.md' }),
+      makeChunk({ chunkId: 'project_doc:README.md:1', sourceKind: 'project_doc', sourceId: 'README.md', chunkIndex: 1 }),
+      makeChunk({ chunkId: 'project_doc:README.md:2', sourceKind: 'project_doc', sourceId: 'README.md', chunkIndex: 2 }),
+    ]);
+
+    backend.deleteSource('myproject', 'project_doc', 'README.md');
+    backend.upsertChunks([
+      makeChunk({ chunkId: 'project_doc:README.md:0', sourceKind: 'project_doc', sourceId: 'README.md' }),
+      makeChunk({ chunkId: 'project_doc:README.md:1', sourceKind: 'project_doc', sourceId: 'README.md', chunkIndex: 1 }),
+    ]);
+
+    expect(backend.countProjectChunks('myproject', ['project_doc'])).toBe(2);
+    expect(
+      db.prepare<[string], { chunk_id: string } | undefined>(
+        'SELECT chunk_id FROM retrieval_chunks WHERE chunk_id = ?'
+      ).get('project_doc:README.md:2')
+    ).toBeUndefined();
+    expect(
+      db.prepare<[string], { rowid: number } | undefined>(
+        'SELECT rowid FROM vec_chunks WHERE chunk_id = ?'
+      ).get('project_doc:README.md:2')
+    ).toBeUndefined();
+  });
 });

--- a/app/api/agents/[agentId]/run/route.ts
+++ b/app/api/agents/[agentId]/run/route.ts
@@ -26,7 +26,7 @@ import { getSettings } from '@/lib/shared/config';
 import { resolveCliBin, resolveCliEnv } from '@/lib/shared/cli-bin';
 import { sqlite } from '@/lib/db';
 import { SqliteVecBackend } from '@/lib/agents/retrieval/sqlite-vec-backend';
-import { retrieveAgentContext } from '@/lib/agents/retrieval/retriever';
+import { retrieveAgentContextDetailed } from '@/lib/agents/retrieval/retriever';
 import { findBlockingRunningJob } from '@/lib/jobs/project-active-job';
 import { checkCliStartGate } from '@/lib/usage/resolve-provider';
 import { resolveAgentPrerequisiteCommand } from '@/lib/agents/issue-cruncher';
@@ -575,7 +575,7 @@ At the end of your run, include a short final section exactly named "TamTam Run 
 
   let retrievedContext: string | null = null;
   if (settings.retrieval_enabled && taskPrompt && isSqliteVecAvailable()) {
-    retrievedContext = await retrieveAgentContext({
+    const retrieval = await retrieveAgentContextDetailed({
       backend: new SqliteVecBackend(sqlite),
       project: agent.project,
       taskPrompt,
@@ -583,6 +583,11 @@ At the end of your run, include a short final section exactly named "TamTam Run 
       scoreThreshold: settings.retrieval_score_threshold,
       ollamaUrl: settings.retrieval_ollama_url,
       embeddingModel: settings.retrieval_embedding_model,
+    });
+    retrievedContext = retrieval.block;
+    job.contextMeta = JSON.stringify({
+      ...(job.contextMeta ? JSON.parse(job.contextMeta) as Record<string, unknown> : {}),
+      retrieval: retrieval.diagnostics,
     });
   }
 

--- a/app/api/projects/[schedId]/retrieval/reindex/route.ts
+++ b/app/api/projects/[schedId]/retrieval/reindex/route.ts
@@ -1,16 +1,34 @@
 import { NextResponse } from 'next/server';
-import { existsSync, readFileSync } from 'fs';
 import { getSettings } from '@/lib/shared/config';
 import { resolveProjectPath } from '@/lib/shared/project-data';
 import { db, schema, sqlite } from '@/lib/db';
-import { eq } from 'drizzle-orm';
+import { eq, and, inArray } from 'drizzle-orm';
 import { SqliteVecBackend } from '@/lib/agents/retrieval/sqlite-vec-backend';
-import { embedText } from '@/lib/agents/retrieval/ollama-embedder';
-import { chunkText } from '@/lib/agents/retrieval/chunker';
-import { hashContent } from '@/lib/agents/retrieval/ingestion';
-import type { SourceKind } from '@/lib/agents/retrieval/backend';
-import { listProjectDocuments } from '@/lib/shared/project-documents';
+import { hashContent, ingestSourceText } from '@/lib/agents/retrieval/ingestion';
 import { getSqliteVecUnavailableDetail, isSqliteVecAvailable } from '@/lib/db/sqlite-vec';
+import { collectProjectRetrievalSources } from '@/lib/agents/retrieval/project-corpus';
+
+function upsertRetrievalRecord(opts: {
+  id: string;
+  project: string;
+  sourceKind: string;
+  sourceId: string;
+  chunkCount: number;
+  contentHash: string;
+  indexedAt: number;
+}): void {
+  db.insert(schema.retrievalRecords)
+    .values(opts)
+    .onConflictDoUpdate({
+      target: schema.retrievalRecords.id,
+      set: {
+        contentHash: opts.contentHash,
+        indexedAt: opts.indexedAt,
+        chunkCount: opts.chunkCount,
+      },
+    })
+    .run();
+}
 
 export async function POST(
   _req: Request,
@@ -38,60 +56,99 @@ export async function POST(
   let totalChunks = 0;
 
   try {
-    const files = listProjectDocuments(projectPath);
+    const sources = collectProjectRetrievalSources(schedId, projectPath);
+    const sourceKinds = ['project_doc', 'skill', 'project_config'] as const;
+    const currentIds = new Set(sources.map((source) => source.recordId));
+    const existingRecords = db.select()
+      .from(schema.retrievalRecords)
+      .where(and(
+        eq(schema.retrievalRecords.project, schedId),
+        inArray(schema.retrievalRecords.sourceKind, [...sourceKinds])
+      ))
+      .all();
+    const existingById = new Map(existingRecords.map((record) => [record.id, record]));
 
-    for (const filePath of files) {
-      if (!existsSync(/*turbopackIgnore: true*/ filePath)) continue;
-      const text = readFileSync(/*turbopackIgnore: true*/ filePath, 'utf-8');
-      const relPath = filePath.replace(projectPath + '/', '');
-      const contentHash = hashContent(text);
-      const recordId = `${schedId}:project_doc:${relPath}`;
+    let missingCount = 0;
+    let staleCount = 0;
+    let indexedCount = 0;
+    let skippedCount = 0;
+    const sourceCounts: Record<string, number> = { project_doc: 0, skill: 0, project_config: 0 };
 
-      const existing = db.select()
-        .from(schema.retrievalRecords)
-        .where(eq(schema.retrievalRecords.id, recordId))
-        .get();
-      if (existing?.contentHash === contentHash) continue;
+    for (const source of sources) {
+      sourceCounts[source.sourceKind] = (sourceCounts[source.sourceKind] ?? 0) + 1;
+      const existing = existingById.get(source.recordId);
+      const contentHash = hashContent(source.text);
+      const timestampStale =
+        !!existing && source.updatedAt != null && existing.indexedAt < source.updatedAt;
+      const isMissing = !existing;
+      const isStale = !!existing && (existing.contentHash !== contentHash || timestampStale);
+      if (isMissing) missingCount += 1;
+      else if (isStale) staleCount += 1;
 
-      const chunks = chunkText(text);
-      const embeddedChunks = await Promise.all(
-        chunks.map(async (chunk, i) => ({
-          chunkId: `project_doc:${relPath}:${i}` as const,
-          text: chunk,
-          embedding: await embedText(chunk, cfg.retrieval_ollama_url, cfg.retrieval_embedding_model, {
+      const { chunkCount, skipped, stored, contentHash: storedHash } = await ingestSourceText({
+        backend,
+        project: schedId,
+        sourceKind: source.sourceKind,
+        sourceId: source.sourceId,
+        text: source.text,
+        metadata: source.metadata,
+        ollamaUrl: cfg.retrieval_ollama_url,
+        embeddingModel: cfg.retrieval_embedding_model,
+        existingHash: existing?.contentHash ?? null,
+      });
+      if (skipped) {
+        skippedCount += 1;
+        if (timestampStale && existing) {
+          upsertRetrievalRecord({
+            id: source.recordId,
             project: schedId,
-            sourceKind: 'project_doc',
-          }),
-          project: schedId,
-          sourceKind: 'project_doc' as SourceKind,
-          sourceId: relPath,
-          chunkIndex: i,
-          metadata: { filePath: relPath },
-        }))
-      );
-      backend.upsertChunks(embeddedChunks);
-      totalChunks += chunks.length;
+            sourceKind: source.sourceKind,
+            sourceId: source.sourceId,
+            chunkCount: existing.chunkCount,
+            contentHash: existing.contentHash,
+            indexedAt: Date.now() / 1000,
+          });
+        }
+        continue;
+      }
+      if (!stored) {
+        throw new Error(`Failed to index ${source.sourceKind}:${source.sourceId}`);
+      }
+      indexedCount += 1;
+      totalChunks += chunkCount;
 
-      db.insert(schema.retrievalRecords)
-        .values({
-          id: recordId,
-          project: schedId,
-          sourceKind: 'project_doc',
-          sourceId: relPath,
-          chunkCount: chunks.length,
-          contentHash,
-          indexedAt: Date.now() / 1000,
-        })
-        .onConflictDoUpdate({
-          target: schema.retrievalRecords.id,
-          set: { contentHash, indexedAt: Date.now() / 1000, chunkCount: chunks.length },
-        })
-        .run();
+      upsertRetrievalRecord({
+        id: source.recordId,
+        project: schedId,
+        sourceKind: source.sourceKind,
+        sourceId: source.sourceId,
+        chunkCount,
+        contentHash: storedHash,
+        indexedAt: Date.now() / 1000,
+      });
     }
+
+    for (const record of existingRecords) {
+      if (currentIds.has(record.id)) continue;
+      backend.deleteSource(schedId, record.sourceKind as 'project_doc' | 'skill' | 'project_config', record.sourceId);
+      db.delete(schema.retrievalRecords).where(eq(schema.retrievalRecords.id, record.id)).run();
+      staleCount += 1;
+    }
+
+    return NextResponse.json({
+      chunks: totalChunks,
+      indexedSources: indexedCount,
+      skippedSources: skippedCount,
+      diagnostics: {
+        status: sources.length > 0 ? 'ok' : 'warning',
+        reason: sources.length > 0 ? 'indexed' : 'empty_corpus',
+        missingSourcesBeforeReindex: missingCount,
+        staleSourcesBeforeReindex: staleCount,
+        sourceCounts,
+      },
+    });
   } catch (err) {
     console.error('[retrieval] reindex failed:', err);
     return NextResponse.json({ error: 'Reindex failed' }, { status: 500 });
   }
-
-  return NextResponse.json({ chunks: totalChunks });
 }

--- a/docs/API.md
+++ b/docs/API.md
@@ -25,7 +25,7 @@ Complete reference for TamTam HTTP API routes. All routes live under `app/api/`.
 - `/api/projects/[schedId]/pause` — Pause project scheduling (POST)
 - `/api/projects/[schedId]/resume` — Resume project scheduling (POST)
 - `/api/projects/[schedId]/detail` — Project scheduling detail (GET)
-- `/api/projects/[schedId]/retrieval/reindex` — Re-index project docs for semantic retrieval (POST). Returns `200 { chunks }` on success, `400 { error }` when retrieval is disabled, `404 { error }` when the project is unknown, and `503 { error, code: 'sqlite_vec_unavailable' }` when the optional native `sqlite-vec` module is not installed in the current environment.
+- `/api/projects/[schedId]/retrieval/reindex` — Re-index the project retrieval corpus (POST). The corpus includes committed project docs, DB-backed skills referenced by that project's agents, and synthesized project config guidance. Returns `200 { chunks, indexedSources, skippedSources, diagnostics }` on success, where `diagnostics` includes pre-reindex `missingSourcesBeforeReindex`, `staleSourcesBeforeReindex`, and per-source counts. Returns `400 { error }` when retrieval is disabled, `404 { error }` when the project is unknown, and `503 { error, code: 'sqlite_vec_unavailable' }` when the optional native `sqlite-vec` module is not installed in the current environment.
 - `/api/config/projects` — Scan workspace for git repos and configure projects (GET, PATCH)
 
 ## Project actions (`by-project/[name]/...`)

--- a/docs/SETTINGS.md
+++ b/docs/SETTINGS.md
@@ -191,7 +191,7 @@ Outbound webhook fired when the release pipeline reaches a terminal state. Suppo
 
 ### Retrieval
 
-Semantic retrieval layer — embeds agent run reports and project docs into a local vector store (`sqlite-vec`) and injects relevant context into agent prompts at run time. Embeddings are generated locally via Ollama (`nomic-embed-text`). Everything is off by default (`retrieval_enabled = false`).
+Semantic retrieval layer — embeds agent run reports plus project-scoped knowledge into a local vector store (`sqlite-vec`) and injects relevant context into agent prompts at run time. The corpus includes committed project docs, DB-backed skills referenced by that project's agents, and synthesized project config guidance. Embeddings are generated locally via Ollama (`nomic-embed-text`). Everything is off by default (`retrieval_enabled = false`).
 
 | Key | Type | Default | Description |
 |---|---|---|---|
@@ -202,7 +202,7 @@ Semantic retrieval layer — embeds agent run reports and project docs into a lo
 | `retrieval_score_threshold` | float | `0.8` | Min similarity score to include a result |
 | `retrieval_manage_ollama` | bool | `true` | Whether TamTam starts Ollama via PM2 if not running |
 
-When enabled, TamTam starts Ollama via PM2 (`ollama-serve`) on boot if not already reachable, pulls `nomic-embed-text` if not installed, and indexes completed agent run reports automatically. Use `POST /api/projects/[schedId]/retrieval/reindex` to index project docs on demand. If the optional native `sqlite-vec` module is not installed in the current environment, retrieval stays unavailable at runtime: agent prompts skip retrieval context, completed runs are not marked as indexed, and the reindex route returns `503 { code: 'sqlite_vec_unavailable' }` instead of failing mid-request.
+When enabled, TamTam starts Ollama via PM2 (`ollama-serve`) on boot if not already reachable, pulls `nomic-embed-text` if not installed, and indexes completed agent run reports automatically. Use `POST /api/projects/[schedId]/retrieval/reindex` to refresh the project corpus on demand; that route reports whether sources were missing or stale before the refresh. Freshness behavior is source-specific: completed agent runs are indexed when they finish, while project docs, DB-backed skills, and synthesized project config are refreshed on explicit reindex against the current file/DB snapshot. At prompt time, TamTam records retrieval diagnostics on the run (`results`, `empty_corpus`, `no_results`, `below_threshold`, or `embed_failed`) so ineffective retrieval can be distinguished from a healthy hit. If the optional native `sqlite-vec` module is not installed in the current environment, retrieval stays unavailable at runtime: agent prompts skip retrieval context, completed runs are not marked as indexed, and the reindex route returns `503 { code: 'sqlite_vec_unavailable' }` instead of failing mid-request.
 
 ### Subscription Budget
 

--- a/lib/agents/retrieval/backend.ts
+++ b/lib/agents/retrieval/backend.ts
@@ -1,4 +1,4 @@
-export type SourceKind = 'agent_run' | 'project_doc' | 'skill';
+export type SourceKind = 'agent_run' | 'project_doc' | 'skill' | 'project_config';
 
 export interface RetrievalChunk {
   chunkId: string;        // `${sourceKind}:${sourceId}:${chunkIndex}` — deterministic
@@ -27,6 +27,7 @@ export interface RetrievalBackend {
     limit: number;
     sourceKinds?: SourceKind[];
   }): RetrievalResult[];
+  countProjectChunks(project: string, sourceKinds?: SourceKind[]): number;
   deleteSource(project: string, sourceKind: SourceKind, sourceId: string): void;
   deleteProject(project: string): void;
 }

--- a/lib/agents/retrieval/chunker.ts
+++ b/lib/agents/retrieval/chunker.ts
@@ -1,15 +1,77 @@
 export const CHUNK_SIZE = 1800;   // ~512 tokens at ~3.5 chars/token
 export const CHUNK_OVERLAP = 200;
 
-export function chunkText(text: string): string[] {
-  if (text.length <= CHUNK_SIZE) return [text];
+function splitIntoBlocks(text: string): string[] {
+  const paragraphs = text
+    .replace(/\r\n/g, '\n')
+    .split(/\n{2,}/)
+    .map((part) => part.trim())
+    .filter(Boolean);
+
+  const blocks: string[] = [];
+  let pendingHeading = '';
+
+  for (const paragraph of paragraphs) {
+    if (/^#{1,6}\s+[^\n]+$/.test(paragraph)) {
+      pendingHeading = pendingHeading ? `${pendingHeading}\n${paragraph}` : paragraph;
+      continue;
+    }
+    blocks.push(pendingHeading ? `${pendingHeading}\n\n${paragraph}` : paragraph);
+    pendingHeading = '';
+  }
+
+  if (pendingHeading) blocks.push(pendingHeading);
+  return blocks;
+}
+
+function splitOversizedBlock(block: string): string[] {
+  if (block.length <= CHUNK_SIZE) return [block];
+
+  const headingMatch = block.match(/^(#{1,6}\s+[^\n]+)\n\n([\s\S]+)$/);
+  const heading = headingMatch ? `${headingMatch[1]}\n\n` : '';
+  const body = headingMatch ? headingMatch[2] : block;
+  const maxBodyLength = Math.max(1, CHUNK_SIZE - heading.length);
   const chunks: string[] = [];
   let start = 0;
-  while (start < text.length) {
-    const end = Math.min(start + CHUNK_SIZE, text.length);
-    chunks.push(text.slice(start, end));
-    if (end === text.length) break;
-    start = end - CHUNK_OVERLAP;
+
+  while (start < body.length) {
+    const end = Math.min(start + maxBodyLength, body.length);
+    chunks.push(`${heading}${body.slice(start, end)}`);
+    if (end === body.length) break;
+    start = Math.max(end - CHUNK_OVERLAP, start + 1);
   }
+
+  return chunks;
+}
+
+export function chunkText(text: string): string[] {
+  if (text.length <= CHUNK_SIZE) return [text];
+
+  const chunks: string[] = [];
+  let current = '';
+
+  for (const block of splitIntoBlocks(text)) {
+    if (block.length > CHUNK_SIZE) {
+      if (current) {
+        chunks.push(current);
+        current = '';
+      }
+      chunks.push(...splitOversizedBlock(block));
+      continue;
+    }
+    if (!current) {
+      current = block;
+      continue;
+    }
+    const combined = `${current}\n\n${block}`;
+    if (combined.length <= CHUNK_SIZE) {
+      current = combined;
+      continue;
+    }
+    chunks.push(current);
+    current = block;
+  }
+
+  if (current) chunks.push(current);
   return chunks;
 }

--- a/lib/agents/retrieval/ingestion.ts
+++ b/lib/agents/retrieval/ingestion.ts
@@ -32,6 +32,55 @@ export interface IngestAgentRunOpts {
   existingHash: string | null;
 }
 
+export interface IngestSourceOpts {
+  backend: RetrievalBackend;
+  project: string;
+  sourceKind: SourceKind;
+  sourceId: string;
+  text: string;
+  metadata: Record<string, string>;
+  ollamaUrl: string;
+  embeddingModel: string;
+  existingHash: string | null;
+}
+
+export async function ingestSourceText(
+  opts: IngestSourceOpts
+): Promise<{ contentHash: string; chunkCount: number; skipped: boolean; stored: boolean }> {
+  const contentHash = hashContent(opts.text);
+
+  if (opts.existingHash === contentHash) {
+    return { contentHash, chunkCount: 0, skipped: true, stored: false };
+  }
+
+  try {
+    const chunks = chunkText(opts.text);
+    const embeddedChunks = await Promise.all(
+      chunks.map(async (chunk, i) => ({
+        chunkId: `${opts.sourceKind}:${opts.sourceId}:${i}`,
+        text: chunk,
+        embedding: await embedText(chunk, opts.ollamaUrl, opts.embeddingModel, {
+          project: opts.project,
+          sourceKind: opts.sourceKind,
+        }),
+        project: opts.project,
+        sourceKind: opts.sourceKind,
+        sourceId: opts.sourceId,
+        chunkIndex: i,
+        metadata: opts.metadata,
+      }))
+    );
+    if (opts.existingHash !== null) {
+      opts.backend.deleteSource(opts.project, opts.sourceKind, opts.sourceId);
+    }
+    opts.backend.upsertChunks(embeddedChunks);
+    return { contentHash, chunkCount: chunks.length, skipped: false, stored: true };
+  } catch (err) {
+    console.warn(`[retrieval] ingestSourceText failed for ${opts.sourceKind}:${opts.sourceId}:`, err);
+    return { contentHash, chunkCount: 0, skipped: false, stored: false };
+  }
+}
+
 export async function ingestAgentRun(
   opts: IngestAgentRunOpts
 ): Promise<{ contentHash: string; skipped: boolean; stored: boolean }> {
@@ -47,33 +96,22 @@ export async function ingestAgentRun(
     return { contentHash, skipped: true, stored: false };
   }
 
-  try {
-    const chunks = chunkText(text);
-    const embeddedChunks = await Promise.all(
-      chunks.map(async (chunk, i) => ({
-        chunkId: `agent_run:${opts.jobId}:${i}` as const,
-        text: chunk,
-        embedding: await embedText(chunk, opts.ollamaUrl, opts.embeddingModel, {
-          project: opts.project,
-          sourceKind: 'agent_run',
-        }),
-        project: opts.project,
-        sourceKind: 'agent_run' as SourceKind,
-        sourceId: opts.jobId,
-        chunkIndex: i,
-        metadata: {
-          agentId: opts.agentId,
-          agentName: opts.agentName,
-          jobId: opts.jobId,
-          exitCode: String(opts.exitCode),
-          completedAt: String(opts.completedAt),
-        },
-      }))
-    );
-    opts.backend.upsertChunks(embeddedChunks);
-    return { contentHash, skipped: false, stored: true };
-  } catch (err) {
-    console.warn('[retrieval] ingestAgentRun failed (best-effort):', err);
-    return { contentHash, skipped: false, stored: false };
-  }
+  const result = await ingestSourceText({
+    backend: opts.backend,
+    project: opts.project,
+    sourceKind: 'agent_run' as SourceKind,
+    sourceId: opts.jobId,
+    text,
+    metadata: {
+      agentId: opts.agentId,
+      agentName: opts.agentName,
+      jobId: opts.jobId,
+      exitCode: String(opts.exitCode),
+      completedAt: String(opts.completedAt),
+    },
+    ollamaUrl: opts.ollamaUrl,
+    embeddingModel: opts.embeddingModel,
+    existingHash: null,
+  });
+  return { contentHash, skipped: result.skipped, stored: result.stored };
 }

--- a/lib/agents/retrieval/project-corpus.ts
+++ b/lib/agents/retrieval/project-corpus.ts
@@ -1,0 +1,161 @@
+import { existsSync, readFileSync, statSync } from 'fs';
+import { inArray, eq } from 'drizzle-orm';
+import { db, schema } from '@/lib/db';
+import { canonicalAgentNameKey } from '@/lib/agents/agent-name';
+import { scanFileAgents } from '@/lib/agents/tamtam-file-agents';
+import { listProjectDocuments } from '@/lib/shared/project-documents';
+import { getBranchContext } from '@/lib/git/git-branch';
+import { loadFileConfig } from '@/lib/skills/tamtam-file-config';
+import type { SourceKind } from './backend';
+
+export interface ProjectRetrievalSource {
+  recordId: string;
+  sourceKind: SourceKind;
+  sourceId: string;
+  text: string;
+  metadata: Record<string, string>;
+  updatedAt: number | null;
+}
+
+function safeJsonArray(value: string | null | undefined): string[] {
+  if (!value) return [];
+  try {
+    const parsed = JSON.parse(value) as unknown;
+    return Array.isArray(parsed) ? parsed.filter((item): item is string => typeof item === 'string') : [];
+  } catch {
+    return [];
+  }
+}
+
+function buildSkillText(skill: { name: string; description: string; content: string }): string {
+  return [
+    `# ${skill.name}`,
+    skill.description.trim() ? skill.description.trim() : '',
+    skill.content.trim(),
+  ].filter(Boolean).join('\n\n');
+}
+
+function buildProjectConfigText(projectPath: string, project: {
+  testCommand: string | null;
+  reviewPromptAddendum: string | null;
+  fixPromptAddendum: string | null;
+  qaUrl: string | null;
+  website: string | null;
+  customActions: string | null;
+} | undefined): string {
+  const fileConfig = loadFileConfig(projectPath);
+  const lines: string[] = ['# Project Configuration'];
+
+  if (fileConfig?.test_command?.trim()) {
+    lines.push(`Committed test command: ${fileConfig.test_command.trim()}`);
+  }
+  if (project?.testCommand?.trim()) {
+    lines.push(`Local test command override: ${project.testCommand.trim()}`);
+  }
+  if (project?.reviewPromptAddendum?.trim()) {
+    lines.push(`Review guidance:\n${project.reviewPromptAddendum.trim()}`);
+  }
+  if (project?.fixPromptAddendum?.trim()) {
+    lines.push(`Fix guidance:\n${project.fixPromptAddendum.trim()}`);
+  }
+  if (fileConfig?.commit_style?.trim()) {
+    lines.push(`Commit style:\n${fileConfig.commit_style.trim()}`);
+  }
+  if (project?.qaUrl?.trim()) {
+    lines.push(`QA URL: ${project.qaUrl.trim()}`);
+  }
+  if (project?.website?.trim()) {
+    lines.push(`Website: ${project.website.trim()}`);
+  }
+  if (fileConfig?.safe_users?.length) {
+    lines.push(`Trusted GitHub users: ${fileConfig.safe_users.join(', ')}`);
+  }
+  if (fileConfig?.custom_actions?.length) {
+    const actions = fileConfig.custom_actions.map((action) => `- ${action.name}: ${action.command}`);
+    lines.push(`Committed custom actions:\n${actions.join('\n')}`);
+  }
+  if (project?.customActions) {
+    try {
+      const actions = JSON.parse(project.customActions) as Array<{ name?: string; command?: string }>;
+      const valid = actions
+        .filter((action) => typeof action?.name === 'string' && typeof action?.command === 'string')
+        .map((action) => `- ${action.name}: ${action.command}`);
+      if (valid.length > 0) {
+        lines.push(`Local custom actions:\n${valid.join('\n')}`);
+      }
+    } catch {}
+  }
+
+  return lines.length > 1 ? lines.join('\n\n') : '';
+}
+
+function collectEffectiveProjectSkillIds(project: string, projectPath: string): string[] {
+  const agentRows = db.select({ name: schema.agents.name, skillIds: schema.agents.skillIds })
+    .from(schema.agents)
+    .where(eq(schema.agents.project, project))
+    .all();
+  const dbAgentKeys = new Set(agentRows.map((row) => canonicalAgentNameKey(row.name)));
+  const skillIds = agentRows.flatMap((row) => safeJsonArray(row.skillIds));
+
+  for (const agent of scanFileAgents(projectPath, project)) {
+    if (dbAgentKeys.has(canonicalAgentNameKey(agent.name))) continue;
+    skillIds.push(...agent.skillIds);
+  }
+
+  return Array.from(new Set(skillIds.filter((id) => !id.startsWith('persona:'))));
+}
+
+export function collectProjectRetrievalSources(project: string, projectPath: string): ProjectRetrievalSource[] {
+  const sources: ProjectRetrievalSource[] = [];
+  const branchContext = getBranchContext(projectPath);
+
+  for (const filePath of listProjectDocuments(projectPath, { includeAgentDocs: branchContext.isDefaultBranch })) {
+    if (!existsSync(/*turbopackIgnore: true*/ filePath)) continue;
+    const text = readFileSync(/*turbopackIgnore: true*/ filePath, 'utf-8');
+    if (!text.trim()) continue;
+    const sourceId = filePath.replace(projectPath + '/', '');
+    sources.push({
+      recordId: `${project}:project_doc:${sourceId}`,
+      sourceKind: 'project_doc',
+      sourceId,
+      text,
+      metadata: { filePath: sourceId },
+      updatedAt: statSync(/*turbopackIgnore: true*/ filePath).mtimeMs / 1000,
+    });
+  }
+
+  const dbSkillIds = collectEffectiveProjectSkillIds(project, projectPath);
+  if (dbSkillIds.length > 0) {
+    const skills = db.select().from(schema.skills).where(inArray(schema.skills.id, dbSkillIds)).all();
+    for (const skill of skills) {
+      const text = buildSkillText(skill);
+      if (!text.trim()) continue;
+      sources.push({
+        recordId: `${project}:skill:${skill.id}`,
+        sourceKind: 'skill',
+        sourceId: skill.id,
+        text,
+        metadata: {
+          skillId: skill.id,
+          skillTitle: skill.name,
+        },
+        updatedAt: skill.updatedAt,
+      });
+    }
+  }
+
+  const projectRow = db.select().from(schema.projects).where(eq(schema.projects.name, project)).get();
+  const configText = buildProjectConfigText(projectPath, projectRow);
+  if (configText.trim()) {
+    sources.push({
+      recordId: `${project}:project_config:current`,
+      sourceKind: 'project_config',
+      sourceId: 'current',
+      text: configText,
+      metadata: { label: 'project config' },
+      updatedAt: null,
+    });
+  }
+
+  return sources;
+}

--- a/lib/agents/retrieval/retriever.ts
+++ b/lib/agents/retrieval/retriever.ts
@@ -10,6 +10,8 @@ export function buildRetrievedContextBlock(results: RetrievalResult[]): string |
         ? `agent_run · ${r.metadata.agentName ?? r.sourceId}`
         : r.sourceKind === 'project_doc'
         ? `project_doc · ${r.metadata.filePath ?? r.sourceId}`
+        : r.sourceKind === 'project_config'
+        ? `project_config · ${r.metadata.label ?? r.sourceId}`
         : `skill · ${r.metadata.skillTitle ?? r.sourceId}`;
     return `[${label}]\n${r.text}`;
   });
@@ -33,7 +35,35 @@ export interface RetrieveAgentContextOpts {
   embeddingModel: string;
 }
 
-export async function retrieveAgentContext(opts: RetrieveAgentContextOpts): Promise<string | null> {
+export interface RetrievalDiagnostics {
+  status: 'ok' | 'warning';
+  reason: 'results' | 'empty_corpus' | 'no_results' | 'below_threshold' | 'embed_failed';
+  corpusChunkCount: number;
+  retrievedCount: number;
+  acceptedCount: number;
+  topScore: number | null;
+  scoreThreshold: number;
+}
+
+export async function retrieveAgentContextDetailed(
+  opts: RetrieveAgentContextOpts
+): Promise<{ block: string | null; diagnostics: RetrievalDiagnostics }> {
+  const corpusChunkCount = opts.backend.countProjectChunks(opts.project, ['project_doc', 'skill', 'project_config', 'agent_run']);
+  if (corpusChunkCount === 0) {
+    return {
+      block: null,
+      diagnostics: {
+        status: 'warning',
+        reason: 'empty_corpus',
+        corpusChunkCount,
+        retrievedCount: 0,
+        acceptedCount: 0,
+        topScore: null,
+        scoreThreshold: opts.scoreThreshold,
+      },
+    };
+  }
+
   try {
     const embedding = await embedText(opts.taskPrompt, opts.ollamaUrl, opts.embeddingModel, {
       project: opts.project,
@@ -41,9 +71,37 @@ export async function retrieveAgentContext(opts: RetrieveAgentContextOpts): Prom
     });
     const results = opts.backend.search({ embedding, project: opts.project, limit: opts.limit });
     const above = results.filter((r) => r.score >= opts.scoreThreshold);
-    return buildRetrievedContextBlock(above);
+    const topScore = results[0]?.score ?? null;
+    return {
+      block: buildRetrievedContextBlock(above),
+      diagnostics: {
+        status: above.length > 0 ? 'ok' : 'warning',
+        reason: results.length === 0 ? 'no_results' : above.length === 0 ? 'below_threshold' : 'results',
+        corpusChunkCount,
+        retrievedCount: results.length,
+        acceptedCount: above.length,
+        topScore,
+        scoreThreshold: opts.scoreThreshold,
+      },
+    };
   } catch (err) {
     console.warn('[retrieval] retrieveAgentContext failed (best-effort):', err);
-    return null;
+    return {
+      block: null,
+      diagnostics: {
+        status: 'warning',
+        reason: 'embed_failed',
+        corpusChunkCount,
+        retrievedCount: 0,
+        acceptedCount: 0,
+        topScore: null,
+        scoreThreshold: opts.scoreThreshold,
+      },
+    };
   }
+}
+
+export async function retrieveAgentContext(opts: RetrieveAgentContextOpts): Promise<string | null> {
+  const result = await retrieveAgentContextDetailed(opts);
+  return result.block;
 }

--- a/lib/agents/retrieval/sqlite-vec-backend.ts
+++ b/lib/agents/retrieval/sqlite-vec-backend.ts
@@ -77,6 +77,21 @@ export class SqliteVecBackend implements RetrievalBackend {
     return results;
   }
 
+  countProjectChunks(project: string, sourceKinds?: SourceKind[]): number {
+    if (!sourceKinds || sourceKinds.length === 0) {
+      const row = this.db.prepare<[string], { count: number }>(
+        'SELECT count(*) AS count FROM retrieval_chunks WHERE project = ?'
+      ).get(project);
+      return row?.count ?? 0;
+    }
+
+    const placeholders = sourceKinds.map(() => '?').join(', ');
+    const row = this.db.prepare<[string, ...string[]], { count: number }>(
+      `SELECT count(*) AS count FROM retrieval_chunks WHERE project = ? AND source_kind IN (${placeholders})`
+    ).get(project, ...sourceKinds);
+    return row?.count ?? 0;
+  }
+
   deleteSource(project: string, sourceKind: SourceKind, sourceId: string): void {
     const rows = this.db
       .prepare<[string, string, string], { chunk_id: string }>(

--- a/lib/shared/project-documents.ts
+++ b/lib/shared/project-documents.ts
@@ -6,6 +6,10 @@ const DOCS_DIR = 'docs';
 const AGENTS_DIR = join('.tamtam', 'agents');
 const ROOT_DOCS = new Set(['CLAUDE.md', 'README.md']);
 
+export interface ListProjectDocumentsOptions {
+  includeAgentDocs?: boolean;
+}
+
 function toPosixPath(path: string): string {
   return path.split(sep).join('/');
 }
@@ -31,8 +35,12 @@ function walkMarkdownFiles(root: string, dir: string): string[] {
   }
 }
 
-export function listProjectDocuments(projectPath: string): string[] {
+export function listProjectDocuments(
+  projectPath: string,
+  opts: ListProjectDocumentsOptions = {}
+): string[] {
   const files = new Set<string>();
+  const includeAgentDocs = opts.includeAgentDocs ?? true;
 
   for (const fileName of ROOT_DOCS) {
     const fullPath = join(/*turbopackIgnore: true*/ projectPath, fileName);
@@ -47,8 +55,10 @@ export function listProjectDocuments(projectPath: string): string[] {
     files.add(filePath);
   }
 
-  for (const filePath of walkMarkdownFiles(projectPath, AGENTS_DIR)) {
-    files.add(filePath);
+  if (includeAgentDocs) {
+    for (const filePath of walkMarkdownFiles(projectPath, AGENTS_DIR)) {
+      files.add(filePath);
+    }
   }
 
   return Array.from(files).sort((a, b) =>


### PR DESCRIPTION
Closes #140

Implemented the retrieval quality pass for issue `#140`. The main changes are in [lib/agents/retrieval/project-corpus.ts](/Users/3h4x/workspace/tamtam/lib/agents/retrieval/project-corpus.ts:1), [lib/agents/retrieval/chunker.ts](/Users/3h4x/workspace/tamtam/lib/agents/retrieval/chunker.ts:1), [app/api/projects/[schedId]/retrieval/reindex/route.ts](/Users/3h4x/workspace/tamtam/app/api/projects/[schedId]/retrieval/reindex/route.ts:1), and [lib/agents/retrieval/retriever.ts](/Users/3h4x/workspace/tamtam/lib/agents/retrieval/retriever.ts:1). Reindexing now covers committed project docs, DB-backed skills actually referenced by that project’s agents, and synthesized project config guidance. Chunking is now heading/paragraph-aware with oversized-section fallback instead of pure fixed-width slicin…

---
Implemented via TamTam from issue [#140](https://github.com/3h4x/tamtam/issues/140).