### PR TITLE
fix: Add pipeline e2e coverage for fix-loop cap so bad reviews cannot spin forever

### DIFF
--- a/e2e/pipeline/fix-loop-cap-do-not-ship.spec.ts
+++ b/e2e/pipeline/fix-loop-cap-do-not-ship.spec.ts
@@ -1,0 +1,79 @@
+import { test, expect } from '@playwright/test';
+import { readFileSync } from 'fs';
+import { join } from 'path';
+import {
+  writeScenario,
+  resetShimState,
+  readShimCalls,
+  enableProject,
+  waitForPipelineCompletion,
+} from './helpers';
+
+const SCENARIO = JSON.parse(
+  readFileSync(join(__dirname, 'scenarios', 'fix-loop-cap-do-not-ship.json'), 'utf-8'),
+);
+
+const PROJECT = 'fix-loop-cap-do-not-ship';
+
+test.describe('Fix-loop cap for DO NOT SHIP reviews', () => {
+  test.beforeAll(async ({ request }) => {
+    writeScenario(PROJECT, SCENARIO.steps);
+    resetShimState(PROJECT);
+    await enableProject(request, PROJECT, { testsDisabled: true });
+
+    const patch = await request.patch('/api/settings', {
+      data: { review_fix_max_iterations: '3' },
+    });
+    expect(patch.ok(), `failed to set review_fix_max_iterations: ${patch.status()}`).toBe(true);
+  });
+
+  test('stops after three fixes and does not commit or push', async ({ request }) => {
+    const releaseResp = await request.post(`/api/projects/by-project/${PROJECT}/release`);
+    expect(releaseResp.status(), `release POST failed: ${await releaseResp.text()}`).toBe(200);
+
+    const result = await waitForPipelineCompletion(request, PROJECT, 180_000);
+    expect(result.status, 'pipeline timed out').toBe('done');
+    expect(result.releaseJob?.['exit_code'], 'release exit code').not.toBe(0);
+
+    const jobsResp = await request.get(`/api/jobs?project=${PROJECT}`);
+    expect(jobsResp.ok()).toBe(true);
+    const { jobs } = await jobsResp.json() as {
+      jobs: Array<{
+        id: string;
+        kind: string;
+        exit_code: number | null;
+        started_at: number;
+        verdict?: string;
+      }>;
+    };
+
+    const ordered = [...jobs].sort((a, b) => a.started_at - b.started_at);
+    const reviewJobs = ordered.filter(j => j.kind === 'review');
+    const fixJobs = ordered.filter(j => j.kind === 'fix');
+    const forbiddenKinds = new Set(['commit', 'push', 'mark-dod', 'pr-wait', 'merge']);
+
+    expect(reviewJobs.length, 'three reviews ran before the cap blocked review #4').toBe(3);
+    expect(reviewJobs.map(j => j.verdict), 'all completed reviews were blocking').toEqual([
+      'DO NOT SHIP',
+      'DO NOT SHIP',
+      'DO NOT SHIP',
+    ]);
+    expect(fixJobs.length, 'three fixes landed before verification budget was exhausted').toBe(3);
+    expect(ordered.filter(j => forbiddenKinds.has(j.kind)), 'no downstream side-effect steps ran').toEqual([]);
+
+    const calls = readShimCalls(PROJECT);
+    expect(calls.some(c => !c.cmd && c.args.includes('commit')), 'git commit was not invoked').toBe(false);
+    expect(calls.some(c => !c.cmd && c.args.includes('push')), 'git push was not invoked').toBe(false);
+    expect(
+      calls.some(c => c.cmd === 'gh' && c.args.includes('issue') && c.args.includes('create')),
+      'DO NOT SHIP exhaustion does not file a follow-up issue',
+    ).toBe(false);
+
+    const releaseId = result.releaseJob?.['id'];
+    expect(typeof releaseId, 'release job id').toBe('string');
+    const releaseDetailResp = await request.get(`/api/jobs/${encodeURIComponent(releaseId as string)}`);
+    expect(releaseDetailResp.ok()).toBe(true);
+    const releaseDetail = await releaseDetailResp.json() as { log?: string };
+    expect(releaseDetail.log ?? '').toContain('review cap reached');
+  });
+});

--- a/e2e/pipeline/global-setup.ts
+++ b/e2e/pipeline/global-setup.ts
@@ -25,6 +25,7 @@ const PROJECTS = [
   'history-live-abort',
   'codex-shim',
   'review-cap-exhaustion',
+  'fix-loop-cap-do-not-ship',
   'review-failure',
   'runs-failure-dns',
   'runs-abort-cancel',

--- a/e2e/pipeline/scenarios/fix-loop-cap-do-not-ship.json
+++ b/e2e/pipeline/scenarios/fix-loop-cap-do-not-ship.json
@@ -1,0 +1,33 @@
+{
+  "description": "Fix-loop cap: three DO NOT SHIP reviews each trigger a fix, then the review cap blocks the fourth review and the release stops before commit or push.",
+  "steps": [
+    {
+      "label": "review-1",
+      "text": "- Finding ID: dns-loop-one\n  Severity: high\n  Root cause: first blocking issue remains\n  Required fix: apply first guard\n\nVerdict: DO NOT SHIP"
+    },
+    {
+      "label": "fix-1",
+      "text": "Fix checklist:\n- Finding ID: dns-loop-one\n  Status: fixed\n  Files changed: src/index.js\n  Tests: not run in shim\n  Remaining risk: follow-up review required"
+    },
+    {
+      "label": "review-2",
+      "text": "- Finding ID: dns-loop-two\n  Severity: high\n  Root cause: second blocking issue remains\n  Required fix: apply second guard\n\nVerdict: DO NOT SHIP"
+    },
+    {
+      "label": "fix-2",
+      "text": "Fix checklist:\n- Finding ID: dns-loop-two\n  Status: fixed\n  Files changed: src/index.js\n  Tests: not run in shim\n  Remaining risk: follow-up review required"
+    },
+    {
+      "label": "review-3",
+      "text": "- Finding ID: dns-loop-three\n  Severity: high\n  Root cause: third blocking issue remains\n  Required fix: apply third guard\n\nVerdict: DO NOT SHIP"
+    },
+    {
+      "label": "fix-3",
+      "text": "Fix checklist:\n- Finding ID: dns-loop-three\n  Status: fixed\n  Files changed: src/index.js\n  Tests: not run in shim\n  Remaining risk: cap should block the next review"
+    },
+    {
+      "label": "review-4",
+      "text": "- Finding ID: dns-loop-four\n  Severity: high\n  Root cause: fourth blocking issue should never be reviewed\n  Required fix: this step must not run\n\nVerdict: DO NOT SHIP"
+    }
+  ]
+}


### PR DESCRIPTION
Closes #72

Implemented focused e2e coverage for the DO NOT SHIP review-fix cap path in #72.

---
Implemented via TamTam from issue [#72](https://github.com/3h4x/tamtam/issues/72).