### PR TITLE
fix: Evaluate workflow for durable agent orchestration

### DIFF
--- a/__tests__/lib/pending-agent-run.test.ts
+++ b/__tests__/lib/pending-agent-run.test.ts
@@ -342,6 +342,85 @@ describe('drainNextAgentRun', () => {
     expect(listQueuedAgents('p1')).toEqual([]);
   });
 
+  it('drops the head after MAX_CONSECUTIVE_FAILURES 5xx replays (circuit breaker)', async () => {
+    // Five identical 500s should trip the breaker and dropHead. Without this,
+    // a route that fails fast (e.g. PM2 spawn EBADF) was re-fired by the
+    // lifecycle drain ~50/sec, producing thousands of dead jobs on a single
+    // queued entry.
+    fetchSpy.mockResolvedValue(jsonResponse({ detail: 'Failed to start' }, 500));
+
+    enqueueAgentRun('p1', { agentId: 'a', agentName: 'A', triggeredBy: 'schedule', prompt: '', enqueuedAt: 1 });
+
+    for (let i = 0; i < 5; i++) {
+      await drainNextAgentRun('p1');
+    }
+
+    expect(fetchSpy).toHaveBeenCalledTimes(5);
+    expect(listQueuedAgents('p1')).toEqual([]);
+  });
+
+  it('resets the failure counter after a successful drain', async () => {
+    // Two 500s, then 200, then two more 500s should not trip the breaker —
+    // a successful drain clears the consecutive-failure count.
+    fetchSpy
+      .mockResolvedValueOnce(jsonResponse({ detail: 'fail' }, 500))
+      .mockResolvedValueOnce(jsonResponse({ detail: 'fail' }, 500))
+      .mockResolvedValueOnce(textResponse('', 200))
+      .mockResolvedValueOnce(jsonResponse({ detail: 'fail' }, 500))
+      .mockResolvedValueOnce(jsonResponse({ detail: 'fail' }, 500));
+
+    enqueueAgentRun('p1', { agentId: 'a', agentName: 'A', triggeredBy: 'schedule', prompt: '', enqueuedAt: 1 });
+    await drainNextAgentRun('p1');
+    await drainNextAgentRun('p1');
+    await drainNextAgentRun('p1'); // 200 → dropHead, clearAttempts
+    expect(listQueuedAgents('p1')).toEqual([]);
+
+    enqueueAgentRun('p1', { agentId: 'b', agentName: 'B', triggeredBy: 'schedule', prompt: '', enqueuedAt: 2 });
+    await drainNextAgentRun('p1');
+    await drainNextAgentRun('p1');
+    // Two failures < 5; head still queued.
+    expect(listQueuedAgents('p1').map((e) => e.agentId)).toEqual(['b']);
+  });
+
+  it('trips the circuit breaker when fetch itself throws repeatedly', async () => {
+    fetchSpy.mockRejectedValue(new Error('ECONNREFUSED'));
+
+    enqueueAgentRun('p1', { agentId: 'a', agentName: 'A', triggeredBy: 'schedule', prompt: '', enqueuedAt: 1 });
+
+    for (let i = 0; i < 5; i++) {
+      await drainNextAgentRun('p1');
+    }
+
+    expect(fetchSpy).toHaveBeenCalledTimes(5);
+    expect(listQueuedAgents('p1')).toEqual([]);
+  });
+
+  it('refuses re-entrance while a drain is already in flight for the project', async () => {
+    // Simulates the runaway: the lifecycle hook calls drainNextAgentRun while
+    // the outer drain is still awaiting its fetch. The recursive call must
+    // bail without making a second POST or removing the head — otherwise a
+    // route returning 500 produces a tight ~50/sec re-fire loop.
+    let release: (v: Response) => void = () => {};
+    fetchSpy.mockReturnValueOnce(
+      new Promise<Response>((res) => {
+        release = res;
+      }),
+    );
+
+    enqueueAgentRun('p1', { agentId: 'a', agentName: 'A', triggeredBy: 'schedule', prompt: '', enqueuedAt: 1 });
+
+    const outer = drainNextAgentRun('p1');
+    // Re-entrant call while outer's fetch is still pending.
+    await drainNextAgentRun('p1');
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect(listQueuedAgents('p1').map((e) => e.agentId)).toEqual(['a']);
+
+    release(jsonResponse({ detail: 'fail' }, 500));
+    await outer;
+    // Failure was recorded but the head stays queued (1/5 attempts).
+    expect(listQueuedAgents('p1').map((e) => e.agentId)).toEqual(['a']);
+  });
+
   it('drops the head and lets a later valid entry drain when 409 reports agent_disabled', async () => {
     fetchSpy
       .mockResolvedValueOnce(

--- a/__tests__/lib/pending-agent-run.test.ts
+++ b/__tests__/lib/pending-agent-run.test.ts
@@ -382,6 +382,49 @@ describe('drainNextAgentRun', () => {
     expect(listQueuedAgents('p1').map((e) => e.agentId)).toEqual(['b']);
   });
 
+  it('resets the breaker state when a queued same-agent entry is replaced', async () => {
+    fetchSpy
+      .mockResolvedValueOnce(jsonResponse({ detail: 'fail' }, 500))
+      .mockResolvedValueOnce(jsonResponse({ detail: 'fail' }, 500))
+      .mockResolvedValueOnce(jsonResponse({ detail: 'fail' }, 500))
+      .mockResolvedValueOnce(jsonResponse({ detail: 'fail' }, 500))
+      .mockResolvedValueOnce(jsonResponse({ detail: 'fail' }, 500));
+
+    enqueueAgentRun('p1', { agentId: 'a', agentName: 'A', triggeredBy: 'schedule', prompt: 'first', enqueuedAt: 1 });
+    await drainNextAgentRun('p1');
+    await drainNextAgentRun('p1');
+    await drainNextAgentRun('p1');
+    await drainNextAgentRun('p1');
+
+    enqueueAgentRun('p1', { agentId: 'a', agentName: 'A', triggeredBy: 'manual', prompt: 'second', enqueuedAt: 2 });
+    await drainNextAgentRun('p1');
+
+    expect(fetchSpy).toHaveBeenCalledTimes(5);
+    expect(listQueuedAgents('p1')).toEqual([
+      { agentId: 'a', agentName: 'A', triggeredBy: 'manual', prompt: 'second', enqueuedAt: 2 },
+    ]);
+  });
+
+  it('does not reset the head breaker state when a later queued agent is replaced', async () => {
+    fetchSpy.mockResolvedValue(jsonResponse({ detail: 'fail' }, 500));
+
+    enqueueAgentRun('p1', { agentId: 'a', agentName: 'A', triggeredBy: 'schedule', prompt: 'first', enqueuedAt: 1 });
+    enqueueAgentRun('p1', { agentId: 'b', agentName: 'B', triggeredBy: 'schedule', prompt: 'queued', enqueuedAt: 2 });
+
+    await drainNextAgentRun('p1');
+    await drainNextAgentRun('p1');
+    await drainNextAgentRun('p1');
+    await drainNextAgentRun('p1');
+
+    enqueueAgentRun('p1', { agentId: 'b', agentName: 'B', triggeredBy: 'manual', prompt: 'updated', enqueuedAt: 3 });
+    await drainNextAgentRun('p1');
+
+    expect(fetchSpy).toHaveBeenCalledTimes(5);
+    expect(listQueuedAgents('p1')).toEqual([
+      { agentId: 'b', agentName: 'B', triggeredBy: 'manual', prompt: 'updated', enqueuedAt: 3 },
+    ]);
+  });
+
   it('trips the circuit breaker when fetch itself throws repeatedly', async () => {
     fetchSpy.mockRejectedValue(new Error('ECONNREFUSED'));
 
@@ -419,6 +462,37 @@ describe('drainNextAgentRun', () => {
     await outer;
     // Failure was recorded but the head stays queued (1/5 attempts).
     expect(listQueuedAgents('p1').map((e) => e.agentId)).toEqual(['a']);
+  });
+
+  it('does not drop a replaced head when an older in-flight drain hits the breaker', async () => {
+    fetchSpy
+      .mockResolvedValueOnce(jsonResponse({ detail: 'fail' }, 500))
+      .mockResolvedValueOnce(jsonResponse({ detail: 'fail' }, 500))
+      .mockResolvedValueOnce(jsonResponse({ detail: 'fail' }, 500))
+      .mockResolvedValueOnce(jsonResponse({ detail: 'fail' }, 500));
+
+    enqueueAgentRun('p1', { agentId: 'a', agentName: 'A', triggeredBy: 'schedule', prompt: 'first', enqueuedAt: 1 });
+    await drainNextAgentRun('p1');
+    await drainNextAgentRun('p1');
+    await drainNextAgentRun('p1');
+    await drainNextAgentRun('p1');
+
+    let release: (v: Response) => void = () => {};
+    fetchSpy.mockReturnValueOnce(
+      new Promise<Response>((res) => {
+        release = res;
+      }),
+    );
+
+    const outer = drainNextAgentRun('p1');
+    enqueueAgentRun('p1', { agentId: 'a', agentName: 'A', triggeredBy: 'manual', prompt: 'second', enqueuedAt: 2 });
+
+    release(jsonResponse({ detail: 'fail' }, 500));
+    await outer;
+
+    expect(listQueuedAgents('p1')).toEqual([
+      { agentId: 'a', agentName: 'A', triggeredBy: 'manual', prompt: 'second', enqueuedAt: 2 },
+    ]);
   });
 
   it('drops the head and lets a later valid entry drain when 409 reports agent_disabled', async () => {

--- a/docs/superpowers/plans/2026-05-13-durable-agent-orchestration.md
+++ b/docs/superpowers/plans/2026-05-13-durable-agent-orchestration.md
@@ -1,0 +1,354 @@
+# Durable Agent Orchestration Evaluation
+
+Date: 2026-05-13
+
+Issue: #145
+
+Decision: defer adoption of `workflow` for the first production durable-agent slice.
+
+## Recommendation
+
+TamTam should not adopt `workflow` as the immediate foundation for agent orchestration in its current deployment model.
+
+The package is credible and increasingly capable, but the first durable slice would force one of these moves:
+
+1. adopt Vercel-hosted workflow infrastructure, which does not match TamTam's PM2/self-hosted runtime, or
+2. adopt a self-hosted Workflow "world", which today means adding PostgreSQL plus `graphile-worker`, or trusting a younger community SQLite/libSQL world.
+
+That is a larger infrastructure change than the agent-orchestration problem alone justifies.
+
+The right call today is:
+
+- defer package adoption
+- keep PM2 as the job execution boundary
+- improve durability inside TamTam's existing SQLite-first architecture first
+- revisit `workflow` only if TamTam is already moving to Postgres or to a formally supported SQLite-compatible world
+
+## What TamTam Has Today
+
+Current agent orchestration is split across a few focused mechanisms:
+
+- `lib/scheduling/internal-scheduler.ts`
+  - in-process scheduled fires
+  - admission checks for project pause, global pause, budget gates, dirty worktree, issue-branch lock, and release lock
+  - invokes `POST /api/agents/{id}/run`
+- `app/api/agents/[agentId]/run/route.ts`
+  - source of truth for agent start
+  - resolves DB/file agents
+  - enforces duplicate protection and queueing
+  - creates the job row before long prerequisite work
+  - writes prerequisite artifacts
+  - composes prompt/docs/memory/retrieval
+  - starts the PM2 one-shot runner
+- `lib/agents/pending-agent-run.ts`
+  - in-memory per-project queue for agent-vs-agent serialization
+  - guards the route's start race with the synchronous start slot
+- `lib/agents/queued-agent-runs.ts`
+  - DB-backed queue when a release pipeline owns the project lock
+  - survives restart
+- `lib/jobs/pm2-jobs.ts`
+  - keeps PM2 as the one-shot execution boundary
+  - writes prompt/log artifacts
+- `lib/jobs/lifecycle.ts`
+  - completion hooks, verdict extraction, fix/review loops, recommendation side effects, and release chaining
+- `instrumentation-node.ts`
+  - restart recovery, probe sweeps, stale queued-run drains, and abandoned inline-job handling
+
+This is not a single workflow engine. It is a set of narrow, practical coordinators around an existing CLI-job model.
+
+## Audit: `workflow` vs TamTam
+
+### Strengths
+
+`workflow` directly targets problems TamTam cares about:
+
+- durable pause/resume
+- persisted execution state
+- retries as code instead of scattered retry loops
+- better step-level observability
+- version pinning for long-running executions
+- built-in support for long-running agent-style processes
+
+If TamTam were designing orchestration from scratch around durable functions instead of PM2 one-shot jobs, this would be a serious candidate.
+
+### Runtime fit
+
+The fit is mixed, not clean.
+
+#### Good fit
+
+- Next.js support exists.
+- The SDK supports self-hosting, not just Vercel.
+- The startup hook model fits TamTam's existing `instrumentation.ts` / `instrumentation-node.ts` pattern.
+
+#### Bad fit
+
+- TamTam is SQLite-first.
+- The production-ready self-hosted Workflow backend is `@workflow/world-postgres`, not SQLite.
+- The local world is explicitly development-only and does not survive restart.
+- The published SQLite-adjacent option listed in Workflow docs is `@workflow-worlds/turso`, a community package rather than a first-party, production-ready world.
+- TamTam's durable unit today is not "a workflow step", it is "a PM2-managed CLI job with a log file, SSE tailing, and lifecycle hooks".
+
+### Behavior fit by agent path
+
+#### Scheduled fires
+
+`workflow` could replace the in-memory timer plus replay logic eventually.
+
+But today TamTam's scheduler does more than timing:
+
+- budget throttling across providers
+- project pause and global pause gates
+- issue-branch skip logic
+- dirty worktree skip logic
+- release lock skip logic
+- stable next-fire anchoring from prior successful runs
+
+Those policies would still need to live in TamTam-specific code even if the timer primitive changed.
+
+#### On-demand runs
+
+The route contract is narrow and user-visible:
+
+- `200 started`
+- `202 queued`
+- `409 already running` / `project busy`
+- persistent `jobs` row and log path
+
+`workflow` could model the pre-start orchestration, but it would not automatically preserve this contract. TamTam would need an adapter layer anyway.
+
+#### Queued agent runs
+
+TamTam has two distinct queues with different semantics:
+
+- in-memory per-project agent serialization
+- DB-backed release-lock queue
+
+`workflow` could unify this eventually, but only if it becomes the owner of queue semantics. A partial adoption would still leave both queues in place.
+
+#### Read-only CTO runs
+
+This is the cleanest candidate for any future first slice because it skips worktree serialization and dirty-worktree gating.
+
+That makes it the best path for experimentation, but not enough to justify the dependency and backend change by itself.
+
+#### Prerequisite commands
+
+TamTam persists prerequisite output to both:
+
+- the main log stream
+- a `.prereq.txt` artifact referenced in `contextMeta`
+
+That side effect is tightly coupled to existing UI and log consumption. A workflow step can run the command, but TamTam still needs the artifact-writing and log-append behavior unchanged.
+
+#### PM2 runner boundary
+
+This is the biggest mismatch.
+
+TamTam's actual agent work is a spawned CLI process owned by PM2, with:
+
+- log files
+- SSE tailing
+- rerun support from saved prompt files
+- lifecycle hooks that read completion from PM2/log state
+
+Using `workflow` would not remove PM2 unless TamTam also rewrote streaming, job lifecycle, and cancellation around workflow-native execution.
+
+If PM2 stays, Workflow mostly becomes a durable wrapper around "decide whether to spawn the same PM2 job".
+
+#### Restart recovery
+
+Workflow is strongest here in principle, but only if it owns the durable state machine end to end.
+
+TamTam currently recovers by combining:
+
+- persisted `jobs`
+- persisted release-lock queue rows
+- process probes
+- scheduler reinstall
+- periodic sweeps
+
+If Workflow only wraps the intake path while PM2/lifecycle remain the true execution owner, restart recovery stays split across both systems.
+
+## Supply-Chain Review
+
+Reviewed on 2026-05-13.
+
+### `workflow`
+
+- package: `workflow`
+- latest version: `4.2.4`
+- last modified in npm metadata: 2026-05-12
+- weekly downloads: 349,015 for 2026-05-06 through 2026-05-12
+- license: Apache-2.0
+- repository: `vercel/workflow`
+- repository created: 2025-10-23
+- GitHub stars at review time: 2,016
+- dependencies: multi-package SDK stack including `@workflow/core`, `@workflow/next`, `@workflow/cli`, `@workflow/errors`, `@workflow/utils`
+- install scripts: no package-install script surfaced in npm metadata for the root `workflow` package
+
+Assessment:
+
+- active and maintained
+- backed by Vercel engineers, not an abandoned side project
+- still young for a foundational orchestration dependency
+- below TamTam's normal "prefer >1M weekly downloads" bar for new dependencies
+
+That does not disqualify it, but it means adoption would need a stronger payoff than "this might simplify some queueing code".
+
+### `@workflow/world-postgres`
+
+- latest version: `4.1.1`
+- last modified in npm metadata: 2026-05-11
+- first-party package in the same Vercel repo
+- hard dependencies include `pg`, `graphile-worker`, `drizzle-orm`, and `@vercel/queue`
+
+Assessment:
+
+- credible
+- production-oriented
+- operationally heavier than TamTam's current SQLite deployment
+- would introduce a second database stack or force a broader storage migration
+
+### `@workflow-worlds/turso`
+
+- latest version: `0.2.2`
+- last modified in npm metadata: 2026-02-09
+- repository: `mizzle-dev/workflow-worlds`
+- single listed maintainer
+- depends on beta Workflow world packages
+
+Assessment:
+
+- interesting because it is SQLite/libSQL-adjacent
+- too early for TamTam's first production orchestration slice
+- not a safe default for a system that already depends on predictable restart recovery
+
+## Why The Decision Is "Defer"
+
+Adopting `workflow` now would add infrastructure complexity before it removes TamTam complexity.
+
+Specifically:
+
+1. TamTam would still keep PM2 jobs, log files, SSE streaming, and lifecycle hooks.
+2. TamTam would still need its own project-specific policy checks and queue semantics.
+3. The production-ready self-hosted backend requires PostgreSQL, which TamTam does not use.
+4. The dev-only local world does not satisfy the restart-recovery requirement.
+5. The SQLite-adjacent community world is not mature enough to anchor a first production slice.
+
+That means the first real adoption would be "TamTam plus Workflow plus PM2 plus existing lifecycle", not "Workflow replaces the fragile parts".
+
+That is the wrong order of operations.
+
+## First Production Slice If We Revisit Later
+
+If TamTam later adopts Postgres, or if a first-party SQLite/libSQL world becomes clearly production-grade, the first slice should be:
+
+- feature flag: `durable_agent_workflows_enabled`
+- scope: manual `readOnly: true` agent runs with no prerequisite command
+- keep existing route: `POST /api/agents/[agentId]/run`
+- keep existing `jobs` row shape, log paths, SSE endpoint, and response payloads
+- keep PM2 as the execution boundary for the actual CLI run
+
+### Why this slice
+
+It avoids the riskiest current concerns:
+
+- no worktree serialization
+- no dirty-worktree block
+- no prerequisite artifact handling
+- no release-pipeline mutation work
+
+But it still exercises the pieces we care about:
+
+- durable acceptance of a run request
+- persisted start state
+- retry around transient start failures
+- restart recovery for the intake path
+
+### Shape of the slice
+
+The workflow would own only the pre-start orchestration:
+
+1. resolve the agent
+2. enforce duplicate/run gate rules for the read-only path
+3. create the `jobs` row immediately
+4. compose prompt/context
+5. call the existing PM2 `startJob()`
+6. persist the started PID and return
+
+After the PM2 process is started, TamTam's existing job lifecycle remains the owner of:
+
+- log streaming
+- status probes
+- completion detection
+- report parsing
+- notifications
+
+This would be a bounded experiment, not a full orchestrator replacement.
+
+### Required invariants
+
+- same HTTP response bodies as today
+- same `job_id` semantics
+- same log file layout
+- same SSE consumer path
+- same cancellation API behavior
+- same lifecycle hooks after process start
+
+## Minimal Migration Plan
+
+Do this only after the storage/runtime precondition is solved.
+
+### Phase 1
+
+- add the feature flag
+- implement a workflow-backed intake path for manual read-only runs without prerequisites
+- shadow-write workflow diagnostics into `contextMeta`
+- do not change the UI contract
+
+### Phase 2
+
+- expand to manual read-only runs with prerequisites
+- define a durable artifact-writing contract for prerequisite output
+
+### Phase 3
+
+- expand to scheduled read-only runs
+- compare workflow retries against existing scheduler replay behavior
+
+### Phase 4
+
+- evaluate replacing one queue at a time
+- start with release-lock queue persistence, not PM2 execution
+
+### Explicit non-goals for the first slice
+
+- replacing PM2
+- replacing SSE/log streaming
+- replacing lifecycle completion hooks
+- rewriting release orchestration
+- migrating the entire scheduler to workflow timers
+
+## Better Near-Term Work Without `workflow`
+
+If the goal is durable orchestration sooner, the simpler path is to make the current architecture more durable inside SQLite:
+
+- persist the per-project pending-agent queue instead of keeping it in memory
+- unify queue drain retries and recovery sweeps under one persisted state model
+- make "starting" a persisted state instead of only a process-local start slot
+- keep PM2, job rows, logs, and SSE exactly as they are
+
+That directly addresses TamTam's actual pain points without a new backend or orchestration runtime.
+
+## Conclusion
+
+`workflow` is promising, but it is not the simplest next step for TamTam.
+
+For TamTam as it exists on 2026-05-13, adopting it now would mostly layer a second orchestration system on top of the current PM2/job/lifecycle model while also pushing the project toward new storage infrastructure.
+
+Recommendation:
+
+- defer adoption now
+- tighten durability in the existing SQLite-first model first
+- revisit `workflow` only alongside a deliberate runtime/storage change, with the first production slice limited to manual read-only agent starts behind a feature flag

--- a/lib/agents/pending-agent-run.ts
+++ b/lib/agents/pending-agent-run.ts
@@ -39,13 +39,20 @@ function sameQueueEntry(a: Pick<QueueEntry, 'agentId' | 'enqueuedAt'> | null | u
 
 function noteFailure(project: string, entry: Pick<QueueEntry, 'agentId' | 'enqueuedAt'>): number {
   const cur = attempts.get(project);
-  const failures = sameQueueEntry(cur, entry) ? cur.consecutiveFailures + 1 : 1;
+  const failures = cur && sameQueueEntry(cur, entry) ? cur.consecutiveFailures + 1 : 1;
   attempts.set(project, { ...entry, consecutiveFailures: failures });
   return failures;
 }
 
 function clearAttempts(project: string): void {
   attempts.delete(project);
+}
+
+function clearAttemptsForEntry(project: string, entry: Pick<QueueEntry, 'agentId' | 'enqueuedAt'>): void {
+  const cur = attempts.get(project);
+  if (sameQueueEntry(cur, entry)) {
+    attempts.delete(project);
+  }
 }
 
 // Synchronous per-project lock held while an agent run is being constructed
@@ -120,7 +127,7 @@ export function enqueueAgentRun(project: string, entry: QueueEntry): void {
   }
   const existing = q.findIndex((e) => e.agentId === entry.agentId);
   if (existing >= 0) {
-    clearAttempts(project);
+    clearAttemptsForEntry(project, q[existing]);
     q[existing] = entry;
     return;
   }

--- a/lib/agents/pending-agent-run.ts
+++ b/lib/agents/pending-agent-run.ts
@@ -23,6 +23,31 @@ const queues = new Map<string, QueueEntry[]>();
 const retryTimers = new Map<string, NodeJS.Timeout>();
 const TEMPORARY_DRAIN_RETRY_MS = 30_000;
 
+// Circuit breaker: drains that fail fast (e.g. PM2 spawn EBADF after FD
+// exhaustion) used to be re-fired by the lifecycle-hook drain at ~50/sec,
+// because nothing tracked that the same head had just failed. We now keep a
+// per-project attempt record so a hot loop of identical failures backs off
+// and eventually drops the head instead of producing thousands of dead jobs.
+const MAX_CONSECUTIVE_FAILURES = 5;
+const inFlight = new Set<string>();
+type AttemptRecord = { agentId: string; enqueuedAt: number; consecutiveFailures: number };
+const attempts = new Map<string, AttemptRecord>();
+
+function sameQueueEntry(a: Pick<QueueEntry, 'agentId' | 'enqueuedAt'> | null | undefined, b: Pick<QueueEntry, 'agentId' | 'enqueuedAt'> | null | undefined): boolean {
+  return !!a && !!b && a.agentId === b.agentId && a.enqueuedAt === b.enqueuedAt;
+}
+
+function noteFailure(project: string, entry: Pick<QueueEntry, 'agentId' | 'enqueuedAt'>): number {
+  const cur = attempts.get(project);
+  const failures = sameQueueEntry(cur, entry) ? cur.consecutiveFailures + 1 : 1;
+  attempts.set(project, { ...entry, consecutiveFailures: failures });
+  return failures;
+}
+
+function clearAttempts(project: string): void {
+  attempts.delete(project);
+}
+
 // Synchronous per-project lock held while an agent run is being constructed
 // (after the listJobs() running-agent check, until createJob() lands the new
 // row in jobsCache). Without this, two concurrent POSTs both observe an
@@ -95,6 +120,7 @@ export function enqueueAgentRun(project: string, entry: QueueEntry): void {
   }
   const existing = q.findIndex((e) => e.agentId === entry.agentId);
   if (existing >= 0) {
+    clearAttempts(project);
     q[existing] = entry;
     return;
   }
@@ -108,6 +134,7 @@ export function dequeueNextAgentRun(project: string): QueueEntry | null {
   if (q.length === 0) {
     queues.delete(project);
     clearDrainRetry(project);
+    clearAttempts(project);
   }
   return next;
 }
@@ -123,6 +150,7 @@ export function listQueuedProjects(): string[] {
 export function clearProjectQueue(project: string): void {
   queues.delete(project);
   clearDrainRetry(project);
+  clearAttempts(project);
 }
 
 export function clearAllQueues(): void {
@@ -132,6 +160,8 @@ export function clearAllQueues(): void {
     clearTimeout(timer);
   }
   retryTimers.clear();
+  attempts.clear();
+  inFlight.clear();
 }
 
 function clearDrainRetry(project: string): void {
@@ -155,6 +185,15 @@ function scheduleDrainRetry(project: string, delayMs = TEMPORARY_DRAIN_RETRY_MS)
 // route handler stays the single source of truth for prompt composition,
 // skill loading, gate checks, etc.
 export async function drainNextAgentRun(project: string): Promise<void> {
+  // Circuit breaker against re-entrant drains. The lifecycle hook fires
+  // drainNextAgentRun() on every agent finish, including the one this drain
+  // just spawned via fetch. Without this guard, a route that fails fast
+  // (e.g. PM2 spawn EBADF) calls markDone → completion hooks → drain →
+  // POST → markDone → … producing ~50 dead jobs/sec on the same queue head.
+  // Serializing per project lets the in-flight POST finish (and dropHead on
+  // success or scheduleDrainRetry on 5xx) before any other caller proceeds.
+  if (inFlight.has(project)) return;
+
   // A route still holds the synchronous "starting" critical section for this
   // project. Leave the queue intact and let that route drain after release so
   // we never drop a head entry on a transient 409 "already starting" reply.
@@ -168,10 +207,20 @@ export async function drainNextAgentRun(project: string): Promise<void> {
   const url = `${baseUrl}/api/agents/${encodeURIComponent(next.agentId)}/run`;
   const dropHead = () => {
     const head = queues.get(project)?.[0];
-    if (head?.agentId === next.agentId) {
+    if (sameQueueEntry(head, next)) {
       dequeueNextAgentRun(project);
     }
   };
+  const tripBreakerIfExhausted = (failures: number, reason: string): boolean => {
+    if (failures < MAX_CONSECUTIVE_FAILURES) return false;
+    console.warn(
+      `[pending-agent-run] circuit breaker tripped for ${next.agentName}/${project} after ${failures} consecutive failures (${reason}) — dropping head`,
+    );
+    dropHead();
+    clearAttempts(project);
+    return true;
+  };
+  inFlight.add(project);
   try {
     const r = await fetch(url, {
       method: 'POST',
@@ -189,6 +238,7 @@ export async function drainNextAgentRun(project: string): Promise<void> {
         // The DB queue now owns this run (survives restart). Drop the in-memory
         // head so we don't double-fire when release recovery replays it.
         dropHead();
+        clearAttempts(project);
         console.log(
           `[pending-agent-run] handed ${next.agentName} to DB queue (${parsed.code}) for ${project}`,
         );
@@ -204,6 +254,7 @@ export async function drainNextAgentRun(project: string): Promise<void> {
 
     if (r.ok) {
       dropHead();
+      clearAttempts(project);
       console.log(`[pending-agent-run] drained ${next.agentName} for ${project} (${r.status})`);
       return;
     }
@@ -235,6 +286,7 @@ export async function drainNextAgentRun(project: string): Promise<void> {
       // don't starve. The scheduler will re-fire eligible agents on its own
       // tick if/when conditions clear.
       dropHead();
+      clearAttempts(project);
       console.warn(
         `[pending-agent-run] dropping ${next.agentName} from queue for ${project}: ${r.status} ${code || 'unknown_409'} ${(parsed?.detail ?? raw).slice(0, 200)}`,
       );
@@ -255,6 +307,7 @@ export async function drainNextAgentRun(project: string): Promise<void> {
     if (r.status === 400 || r.status === 404) {
       const body = await r.text().catch(() => '');
       dropHead();
+      clearAttempts(project);
       console.warn(
         `[pending-agent-run] dropping ${next.agentName} from queue for ${project}: ${r.status} ${body.slice(0, 200)}`,
       );
@@ -262,12 +315,29 @@ export async function drainNextAgentRun(project: string): Promise<void> {
     }
 
     if (!r.ok) {
+      // 5xx (and any other unhandled non-success). Previously this branch
+      // logged and returned without rescheduling, so the next lifecycle
+      // drain re-fired the same head instantly — a route that fails fast
+      // (EBADF, OOM-spawn, transient handler crash) would churn ~50/sec.
+      // Now: count the failure, trip the breaker after the cap, and back
+      // off via the retry timer otherwise.
       const body = await r.text().catch(() => '');
+      const failures = noteFailure(project, next);
+      if (tripBreakerIfExhausted(failures, `HTTP ${r.status}`)) return;
+      scheduleDrainRetry(project);
       console.warn(
-        `[pending-agent-run] drain ${next.agentName} for ${project} failed: ${r.status} ${body.slice(0, 200)}`,
+        `[pending-agent-run] drain ${next.agentName} for ${project} failed: ${r.status} ${body.slice(0, 200)} (attempt ${failures}/${MAX_CONSECUTIVE_FAILURES})`,
       );
     }
   } catch (e) {
-    console.error(`[pending-agent-run] drain error for ${project}/${next.agentName}:`, e);
+    // Network-level failure (route unreachable, abort, fetch crash). Treat
+    // identically to 5xx: count, retry, trip after the cap.
+    const failures = noteFailure(project, next);
+    if (!tripBreakerIfExhausted(failures, 'fetch error')) {
+      scheduleDrainRetry(project);
+    }
+    console.error(`[pending-agent-run] drain error for ${project}/${next.agentName} (attempt ${failures}/${MAX_CONSECUTIVE_FAILURES}):`, e);
+  } finally {
+    inFlight.delete(project);
   }
 }


### PR DESCRIPTION
Closes #145

Added the evaluation note at [2026-05-13-durable-agent-orchestration.md](/Users/3h4x/workspace/tamtam/docs/superpowers/plans/2026-05-13-durable-agent-orchestration.md). It audits TamTam’s current scheduler/queue/PM2/lifecycle split, compares it to `workflow`, and recommends `defer` rather than adopt now.

The note’s main conclusion is that `workflow` is credible, but in TamTam’s current SQLite + PM2 model it would add infrastructure before it removes complexity. The production-ready self-hosted path currently points to `@workflow/world-postgres`, while the SQLite-adjacent Turso world is still too young for TamTam’s first durable slice. The document also defines the smallest future slice if this gets revisited: a feature-flagged, manual `readOnly` agent-start path that preserves existing j…

---
Implemented via TamTam from issue [#145](https://github.com/3h4x/tamtam/issues/145).