### PR TITLE
fix: Expose retrieved context sources so agent runs stay auditable

### DIFF
--- a/__tests__/components/terminal-session-restore.test.ts
+++ b/__tests__/components/terminal-session-restore.test.ts
@@ -1,0 +1,116 @@
+/* @vitest-environment jsdom */
+
+import React from 'react'
+import { afterEach, describe, expect, it } from 'vitest'
+import { createRoot } from 'react-dom/client'
+import { flushSync } from 'react-dom'
+import { TerminalMessages } from '@/components/terminal/TerminalMessages'
+import {
+  retrievedContextEntryFromMeta,
+  retrievedContextSourcesFromMeta,
+} from '@/components/terminal/session-restore'
+import type { TermEntry } from '@/lib/terminal/terminal-session-store'
+
+afterEach(() => {
+  document.body.innerHTML = ''
+})
+
+describe('terminal retrieval context restore helpers', () => {
+  it('returns no sources when context metadata has no retrieval source list', () => {
+    expect(retrievedContextSourcesFromMeta(JSON.stringify({ retrieval: { acceptedCount: 0 } }))).toEqual([])
+    expect(retrievedContextEntryFromMeta(JSON.stringify({ docs: [] }))).toBeNull()
+  })
+
+  it('builds a compact Retrieved Context status entry when source metadata exists', () => {
+    const entry = retrievedContextEntryFromMeta(JSON.stringify({
+      retrieval: {
+        sources: [
+          {
+            sourceKind: 'project_doc',
+            sourceId: 'docs/AGENT.md',
+            project: 'tamtam',
+            score: 0.93,
+            rank: 1,
+            preview: 'Agent intake stores context metadata.',
+          },
+        ],
+      },
+    }))
+
+    expect(entry).toEqual({
+      role: 'status',
+      text: 'Retrieved Context\n1. project_doc docs/AGENT.md (tamtam score 0.93) - Agent intake stores context metadata.',
+    })
+  })
+})
+
+function renderTerminalMessages(history: TermEntry[]) {
+  const container = document.createElement('div')
+  document.body.appendChild(container)
+  const root = createRoot(container)
+  flushSync(() => {
+    root.render(React.createElement(TerminalMessages, {
+      history,
+      streaming: false,
+      streamBuffer: '',
+      thinkingBuffer: '',
+      rawBuffer: '',
+      streamTools: [],
+      streamIsRaw: false,
+      showThinking: false,
+      messageQueue: [],
+      pendingImageUrls: [],
+      pendingImages: [],
+      elapsedMs: 0,
+      idleSec: 0,
+      spinnerFrame: 0,
+      autoScroll: true,
+      allItems: [],
+      onScroll: () => {},
+      onScrollToBottom: () => {},
+      onToggleItem: () => {},
+      onRemoveImage: () => {},
+      onClearImages: () => {},
+      onClearQueueItem: () => {},
+      onCancel: () => {},
+      termRef: React.createRef<HTMLDivElement>(),
+      lastError: null,
+      onResume: () => {},
+      onDismissError: () => {},
+    }))
+  })
+  return {
+    container,
+    unmount: () => {
+      root.unmount()
+      container.remove()
+    },
+  }
+}
+
+describe('TerminalMessages retrieved context section', () => {
+  it('renders the Retrieved Context section only when metadata produces an entry', () => {
+    const missingEntry = retrievedContextEntryFromMeta(JSON.stringify({ retrieval: { acceptedCount: 0 } }))
+    const presentEntry = retrievedContextEntryFromMeta(JSON.stringify({
+      retrieval: {
+        sources: [{
+          sourceKind: 'skill',
+          sourceId: 'release-readiness',
+          project: 'tamtam',
+          score: 0.88,
+          rank: 1,
+          preview: 'Use release pipeline guardrails.',
+        }],
+      },
+    }))
+
+    const without = renderTerminalMessages(missingEntry ? [missingEntry] : [])
+    expect(without.container.textContent).not.toContain('Retrieved Context')
+    without.unmount()
+
+    const withSection = renderTerminalMessages(presentEntry ? [presentEntry] : [])
+    expect(withSection.container.textContent).toContain('Retrieved Context')
+    expect(withSection.container.textContent).toContain('release-readiness')
+    withSection.unmount()
+  })
+})

--- a/__tests__/lib/retrieval/retriever.test.ts
+++ b/__tests__/lib/retrieval/retriever.test.ts
@@ -91,6 +91,39 @@ describe('retrieveAgentContext', () => {
     expect(result).toContain('Auth reviewed OK');
   });
 
+  it('records bounded accepted source metadata in diagnostics', async () => {
+    mockSearch.mockReturnValue([
+      {
+        text: `Auth reviewed OK ${'x'.repeat(240)}`,
+        sourceKind: 'project_doc',
+        sourceId: 'docs/AUTH.md',
+        score: 0.91,
+        metadata: { filePath: 'docs/AUTH.md' },
+      },
+    ]);
+
+    const result = await retrieveAgentContextDetailed({
+      backend: mockBackend,
+      project: 'myproject',
+      taskPrompt: 'review auth',
+      limit: 5,
+      scoreThreshold: 0.8,
+      ollamaUrl: 'http://localhost:11434',
+      embeddingModel: 'nomic-embed-text',
+    });
+
+    expect(result.diagnostics.sources).toEqual([
+      expect.objectContaining({
+        sourceKind: 'project_doc',
+        sourceId: 'docs/AUTH.md',
+        project: 'myproject',
+        score: 0.91,
+        rank: 1,
+      }),
+    ]);
+    expect(result.diagnostics.sources?.[0]?.preview.length).toBeLessThanOrEqual(180);
+  });
+
   it('returns null when embedText throws (Ollama unreachable)', async () => {
     mockEmbed.mockRejectedValueOnce(new Error('ECONNREFUSED'));
     const result = await retrieveAgentContext({
@@ -141,5 +174,6 @@ describe('retrieveAgentContext', () => {
     expect(result.block).toBeNull();
     expect(result.diagnostics.reason).toBe('below_threshold');
     expect(result.diagnostics.topScore).toBe(0.4);
+    expect(result.diagnostics.sources).toBeUndefined();
   });
 });

--- a/__tests__/lib/start-push.test.ts
+++ b/__tests__/lib/start-push.test.ts
@@ -49,6 +49,7 @@ vi.mock('@/lib/shared/shell', () => ({ exec: mocks.execMock }));
 vi.mock('@/lib/shared/config', () => ({
   getSettings: () => ({ commit_style: '' }),
   getPipelineModel: () => 'haiku',
+  getPermissionModeFlag: () => '',
 }));
 vi.mock('@/lib/scheduling/scheduling', () => ({
   getImproveConfig: () => ({ claudeBin: 'claude', projects: {}, logDir: '/tmp' }),
@@ -916,7 +917,11 @@ describe('generateCommitMessage', () => {
     vi.doUnmock('@/lib/pipeline/start-commit');
     execMock = vi.fn();
     vi.doMock('@/lib/shared/shell', () => ({ exec: execMock }));
-    vi.doMock('@/lib/shared/config', () => ({ getSettings: () => ({ commit_style: '' }), getPipelineModel: () => 'haiku' }));
+    vi.doMock('@/lib/shared/config', () => ({
+      getSettings: () => ({ commit_style: '' }),
+      getPipelineModel: () => 'haiku',
+      getPermissionModeFlag: () => '',
+    }));
     vi.doMock('@/lib/scheduling/scheduling', () => ({
       getImproveConfig: () => ({ claudeBin: 'claude', projects: {}, logDir: '/tmp' }),
       getProjectTestConfig: vi.fn().mockReturnValue(null),
@@ -1092,6 +1097,7 @@ describe('generateCommitMessage', () => {
     vi.doMock('@/lib/shared/config', () => ({
       getSettings: () => ({ commit_style: 'Always include a ticket number like PROJ-123.' }),
       getPipelineModel: () => 'haiku',
+      getPermissionModeFlag: () => '',
     }));
     vi.doMock('@/lib/scheduling/scheduling', () => ({
       getImproveConfig: () => ({ claudeBin: 'claude', projects: {}, logDir: '/tmp' }),

--- a/components/terminal/session-restore.ts
+++ b/components/terminal/session-restore.ts
@@ -21,6 +21,15 @@ export interface RestorableJob {
   provider?: string | null
 }
 
+export interface RetrievedContextSource {
+  sourceKind: string
+  sourceId: string
+  project: string
+  score?: number
+  rank?: number
+  preview?: string
+}
+
 interface JobLogDetail {
   log?: string | null
   log_pruned?: boolean
@@ -84,6 +93,46 @@ export function contextItemsFromMeta(contextMeta: string | null | undefined): {
   }
 }
 
+export function retrievedContextSourcesFromMeta(contextMeta: string | null | undefined): RetrievedContextSource[] {
+  if (!contextMeta) return []
+  try {
+    const meta = JSON.parse(contextMeta)
+    const sources = meta?.retrieval?.sources
+    if (!Array.isArray(sources)) return []
+    return sources
+      .filter((source): source is RetrievedContextSource =>
+        typeof source?.sourceKind === 'string' &&
+        typeof source?.sourceId === 'string' &&
+        typeof source?.project === 'string'
+      )
+      .map((source, index) => ({
+        sourceKind: source.sourceKind,
+        sourceId: source.sourceId,
+        project: source.project,
+        score: typeof source.score === 'number' ? source.score : undefined,
+        rank: typeof source.rank === 'number' ? source.rank : index + 1,
+        preview: typeof source.preview === 'string' ? source.preview : undefined,
+      }))
+  } catch {
+    return []
+  }
+}
+
+export function retrievedContextEntryFromMeta(contextMeta: string | null | undefined): TermEntry | null {
+  const sources = retrievedContextSourcesFromMeta(contextMeta)
+  if (sources.length === 0) return null
+  const lines = sources.map((source, index) => {
+    const rank = source.rank ?? index + 1
+    const score = typeof source.score === 'number' ? ` score ${source.score.toFixed(2)}` : ''
+    const preview = source.preview ? ` - ${source.preview}` : ''
+    return `${rank}. ${source.sourceKind} ${source.sourceId} (${source.project}${score})${preview}`
+  })
+  return {
+    role: 'status',
+    text: ['Retrieved Context', ...lines].join('\n'),
+  }
+}
+
 async function fetchJobs(url: string): Promise<RestorableJob[]> {
   const res = await fetch(url)
   const data = await res.json()
@@ -124,6 +173,9 @@ export async function buildEntriesForCompletedJobs(jobs: RestorableJob[]): Promi
   const entries: TermEntry[] = []
   jobs.forEach((job, index) => {
     const jobWithDetail = mergePromptDetail(job, logData[index])
+    const retrievedContextEntry = retrievedContextEntryFromMeta(job.context_meta)
+    if (retrievedContextEntry) entries.push(retrievedContextEntry)
+
     const prompt = restoredPrompt(jobWithDetail)
     if (prompt) entries.push({ role: 'user', text: prompt })
 

--- a/components/terminal/useSessionManager.ts
+++ b/components/terminal/useSessionManager.ts
@@ -15,6 +15,7 @@ import {
   contextItemsFromMeta,
   fetchSessionJobs,
   isRestorableSessionKind,
+  retrievedContextEntryFromMeta,
   restoredPrompt,
 } from './session-restore'
 
@@ -101,6 +102,8 @@ export function useSessionManager(projectName: string) {
           const entries = await buildEntriesForCompletedJobs(completedMatches)
           router.replace(`/project/${projectName}/terminal/${session.sessionId}`)
           if (lastIsRunning) {
+            const retrievedContextEntry = retrievedContextEntryFromMeta(lastMatch.context_meta)
+            if (retrievedContextEntry) entries.push(retrievedContextEntry)
             const prompt = restoredPrompt(lastMatch)
             if (prompt) entries.push({ role: 'user', text: prompt })
             terminalStore.update(projectName, () => ({
@@ -164,6 +167,8 @@ export function useSessionManager(projectName: string) {
       const data = await res.json() as JobDetail & { exit_code?: number | null; log?: string | null; log_pruned?: boolean }
       const entries: TermEntry[] = []
       const prompt = data.user_prompt || data.prompt || session.prompt
+      const retrievedContextEntry = retrievedContextEntryFromMeta(data.context_meta)
+      if (retrievedContextEntry) entries.push(retrievedContextEntry)
       if (prompt) entries.push({ role: 'user', text: prompt })
       const exitCode = typeof data.exit_code === 'number' ? data.exit_code : session.exitCode
       const exitEntry = exitCode !== null && exitCode !== undefined

--- a/components/terminal/useTerminalBootstrap.ts
+++ b/components/terminal/useTerminalBootstrap.ts
@@ -13,6 +13,7 @@ import {
   countSessionJobs,
   fetchSessionJobs,
   isRestorableSessionKind,
+  retrievedContextEntryFromMeta,
   restoredPrompt,
 } from './session-restore'
 
@@ -195,6 +196,8 @@ export function useTerminalBootstrap({
 
         const sessionProvider = matches.find(m => m.provider)?.provider ?? null
         if (lastIsRunning) {
+          const retrievedContextEntry = retrievedContextEntryFromMeta(lastMatch.context_meta)
+          if (retrievedContextEntry) entries.push(retrievedContextEntry)
           const prompt = restoredPrompt(lastMatch)
           if (prompt) entries.push({ role: 'user', text: prompt })
           terminalStore.update(projectName, () => ({
@@ -265,6 +268,9 @@ export function useTerminalBootstrap({
         entries.push({ role: 'status', text: startedLabel ? `${kind} · ${startedLabel}` : kind })
 
         const jobPrompt = data.user_prompt || data.prompt
+        const retrievedContextEntry = retrievedContextEntryFromMeta(data.context_meta)
+        if (retrievedContextEntry) entries.push(retrievedContextEntry)
+
         if (jobPrompt) {
           entries.push({ role: 'user', text: jobPrompt })
         }

--- a/docs/AGENT.md
+++ b/docs/AGENT.md
@@ -191,6 +191,8 @@ returns `409` with `code: "project_busy"` plus the blocking job id:
 
 The agent starts immediately as a PM2 process. Output is streamed to a log file and can be watched via SSE at `/api/streaming/{job_id}`.
 
+When retrieval is enabled and prompt-time search returns snippets above the configured score threshold, the intake workflow prepends a `## Retrieved Context` block to the prompt and records a bounded audit trail on the job's `context_meta.retrieval.sources`. Each source entry includes `sourceKind`, `sourceId`, `project`, `rank`, `score`, and a short preview only; full retrieved bodies are not duplicated into metadata. Restoring the run in the terminal session view renders a compact `Retrieved Context` section before the user prompt so operators can inspect what was injected. Runs with retrieval disabled, an empty corpus, failed embedding, or no accepted snippets do not get retrieval metadata.
+
 When an agent finishes, TamTam asks it to include a short `TamTam Run Report` in the final response. The lifecycle parser stores a concise `work_summary` and `modified_files` JSON array on the job row. If a scheduled agent repeatedly finds no actionable work and changes no files, TamTam creates an open project recommendation instead of silently changing the schedule. That `agent_schedule_backoff` recommendation now carries a structured rationale payload copied from the run report summary (`summary`, `actionableWork`, `filesChangedCount`, cadence, confidence, and `sourceJobId` when present), and the recommendations UI renders that metadata in a compact "Why" panel so operators can see why the slower cadence was suggested.
 
 ### Read-only Agent Runs

--- a/lib/agents/intake-workflow.ts
+++ b/lib/agents/intake-workflow.ts
@@ -327,7 +327,9 @@ At the end of your run, include a short final section exactly named "TamTam Run 
         embeddingModel: settings.retrieval_embedding_model,
       });
       retrievedContext = retrieval.block;
-      contextMetaObj.retrieval = retrieval.diagnostics;
+      if ((retrieval.diagnostics.sources?.length ?? 0) > 0) {
+        contextMetaObj.retrieval = retrieval.diagnostics;
+      }
     } catch (e) {
       console.warn('[intake-workflow] retrieval failed, skipping:', errMsg(e));
     }

--- a/lib/agents/retrieval/retriever.ts
+++ b/lib/agents/retrieval/retriever.ts
@@ -1,6 +1,14 @@
 import { embedText } from './ollama-embedder';
 import type { RetrievalBackend, RetrievalResult } from './backend';
 
+const PREVIEW_MAX_CHARS = 180;
+
+function previewText(text: string): string {
+  const normalized = text.replace(/\s+/g, ' ').trim();
+  if (normalized.length <= PREVIEW_MAX_CHARS) return normalized;
+  return `${normalized.slice(0, PREVIEW_MAX_CHARS - 3).trimEnd()}...`;
+}
+
 export function buildRetrievedContextBlock(results: RetrievalResult[]): string | null {
   if (results.length === 0) return null;
 
@@ -43,6 +51,16 @@ export interface RetrievalDiagnostics {
   acceptedCount: number;
   topScore: number | null;
   scoreThreshold: number;
+  sources?: RetrievedContextSource[];
+}
+
+export interface RetrievedContextSource {
+  sourceKind: RetrievalResult['sourceKind'];
+  sourceId: string;
+  project: string;
+  score: number;
+  rank: number;
+  preview: string;
 }
 
 export async function retrieveAgentContextDetailed(
@@ -72,6 +90,14 @@ export async function retrieveAgentContextDetailed(
     const results = await opts.backend.search({ embedding, project: opts.project, limit: opts.limit });
     const above = results.filter((r) => r.score >= opts.scoreThreshold);
     const topScore = results[0]?.score ?? null;
+    const sources: RetrievedContextSource[] = above.map((result, index) => ({
+      sourceKind: result.sourceKind,
+      sourceId: result.sourceId,
+      project: opts.project,
+      score: result.score,
+      rank: index + 1,
+      preview: previewText(result.text),
+    }));
     return {
       block: buildRetrievedContextBlock(above),
       diagnostics: {
@@ -82,6 +108,7 @@ export async function retrieveAgentContextDetailed(
         acceptedCount: above.length,
         topScore,
         scoreThreshold: opts.scoreThreshold,
+        ...(sources.length > 0 ? { sources } : {}),
       },
     };
   } catch (err) {


### PR DESCRIPTION
Closes #99

Implemented #99 retrieval source audit metadata and terminal visibility.

---
Implemented via TamTam from issue [#99](https://github.com/3h4x/tamtam/issues/99).