### PR TITLE
fix: Auto-revert post-merge failures so PR Workflow closes the quality loop

### DIFF
--- a/__tests__/api/action.test.ts
+++ b/__tests__/api/action.test.ts
@@ -99,6 +99,8 @@ async function applyDdl(handle: TestDbHandle): Promise<void> {
       auto_commit_enabled boolean DEFAULT false,
       auto_push_enabled boolean DEFAULT false,
       auto_pr_merge_enabled boolean DEFAULT false,
+      post_merge_watch_minutes integer DEFAULT 0,
+      auto_revert_enabled boolean DEFAULT false,
       pr_workflow_enabled boolean DEFAULT false,
       release_after_run boolean DEFAULT false,
       issue_auto_branch boolean DEFAULT true,

--- a/__tests__/api/agent-run-readonly.test.ts
+++ b/__tests__/api/agent-run-readonly.test.ts
@@ -40,6 +40,8 @@ async function applyDdl(handle: TestDbHandle): Promise<void> {
       auto_commit_enabled boolean DEFAULT false,
       auto_push_enabled boolean DEFAULT false,
       auto_pr_merge_enabled boolean DEFAULT false,
+      post_merge_watch_minutes integer DEFAULT 0,
+      auto_revert_enabled boolean DEFAULT false,
       release_after_run boolean DEFAULT false,
       issue_auto_branch boolean DEFAULT true,
       last_push_error text,

--- a/__tests__/api/agents.test.ts
+++ b/__tests__/api/agents.test.ts
@@ -103,6 +103,8 @@ async function applyDdl(handle: TestDbHandle): Promise<void> {
       auto_commit_enabled boolean DEFAULT false,
       auto_push_enabled boolean DEFAULT false,
       auto_pr_merge_enabled boolean DEFAULT false,
+      post_merge_watch_minutes integer DEFAULT 0,
+      auto_revert_enabled boolean DEFAULT false,
       release_after_run boolean DEFAULT false,
       pr_workflow_enabled boolean DEFAULT false,
       issue_auto_branch boolean DEFAULT true,

--- a/__tests__/api/config-projects.test.ts
+++ b/__tests__/api/config-projects.test.ts
@@ -32,6 +32,8 @@ async function applyDdl(handle: TestDbHandle): Promise<void> {
       auto_commit_enabled boolean DEFAULT false,
       auto_push_enabled boolean DEFAULT false,
       auto_pr_merge_enabled boolean DEFAULT false,
+      post_merge_watch_minutes integer DEFAULT 0,
+      auto_revert_enabled boolean DEFAULT false,
       release_after_run boolean DEFAULT false,
       issue_auto_branch boolean DEFAULT true,
       last_push_error text,

--- a/__tests__/api/projects.test.ts
+++ b/__tests__/api/projects.test.ts
@@ -25,6 +25,8 @@ async function applyDdl(handle: TestDbHandle): Promise<void> {
       auto_commit_enabled boolean DEFAULT false,
       auto_push_enabled boolean DEFAULT false,
       auto_pr_merge_enabled boolean DEFAULT false,
+      post_merge_watch_minutes integer DEFAULT 0,
+      auto_revert_enabled boolean DEFAULT false,
       release_after_run boolean DEFAULT false,
       issue_auto_branch boolean DEFAULT true,
       last_push_error text,

--- a/__tests__/api/scheduler-health.test.ts
+++ b/__tests__/api/scheduler-health.test.ts
@@ -43,6 +43,8 @@ async function applyDdl(handle: TestDbHandle): Promise<void> {
       auto_commit_enabled boolean DEFAULT false,
       auto_push_enabled boolean DEFAULT false,
       auto_pr_merge_enabled boolean DEFAULT false,
+      post_merge_watch_minutes integer DEFAULT 0,
+      auto_revert_enabled boolean DEFAULT false,
       release_after_run boolean DEFAULT false,
       pr_workflow_enabled boolean DEFAULT false,
       issue_auto_branch boolean DEFAULT true,

--- a/__tests__/lib/cli-bin.test.ts
+++ b/__tests__/lib/cli-bin.test.ts
@@ -64,6 +64,7 @@ function makeSettings(overrides: Partial<TamTamConfig> = {}): TamTamConfig {
     notification_on_fix_loop_exhausted: false,
     notification_on_review_do_not_ship: false,
     notification_on_agent_run_fail: false,
+    notification_on_post_merge_revert: false,
     notification_throttle_window_seconds: 900,
     notification_throttle_overrides: { release_fail: 0, release_aborted: 0 },
     pipeline_model_review: '',

--- a/__tests__/lib/config.test.ts
+++ b/__tests__/lib/config.test.ts
@@ -148,6 +148,7 @@ describe('config', () => {
         notification_on_review_do_not_ship: false,
         notification_on_agent_run_fail: false,
         notification_on_budget_blocked: false,
+        notification_on_post_merge_revert: false,
         notification_throttle_window_seconds: 900,
         notification_throttle_overrides: { release_fail: 0, release_aborted: 0 },
         budget_block_runs_enabled: false,

--- a/__tests__/lib/pipeline-steps.test.ts
+++ b/__tests__/lib/pipeline-steps.test.ts
@@ -26,7 +26,7 @@ describe('getPipelineSteps', () => {
   beforeEach(() => { _resetExtraSteps(); });
 
   it('returns the unified built-in step registry in order', () => {
-    expect(getPipelineSteps().map(s => s.id)).toEqual(['test', 'review', 'fix', 'commit', 'push', 'dod', 'merge']);
+    expect(getPipelineSteps().map(s => s.id)).toEqual(['test', 'review', 'fix', 'commit', 'push', 'dod', 'merge', 'soak']);
   });
 
   it('marks fix and dod as mandatory', () => {

--- a/__tests__/lib/project-data.test.ts
+++ b/__tests__/lib/project-data.test.ts
@@ -28,6 +28,8 @@ async function applyDdl(handle: TestDbHandle): Promise<void> {
       auto_commit_enabled boolean DEFAULT false,
       auto_push_enabled boolean DEFAULT false,
       auto_pr_merge_enabled boolean DEFAULT false,
+      post_merge_watch_minutes integer DEFAULT 0,
+      auto_revert_enabled boolean DEFAULT false,
       pr_workflow_enabled boolean DEFAULT false,
       release_after_run boolean DEFAULT false,
       issue_auto_branch boolean DEFAULT true,

--- a/__tests__/lib/retrieval/project-corpus.test.ts
+++ b/__tests__/lib/retrieval/project-corpus.test.ts
@@ -58,6 +58,8 @@ async function applyDdl(handle: TestDbHandle): Promise<void> {
       auto_commit_enabled boolean DEFAULT false,
       auto_push_enabled boolean DEFAULT false,
       auto_pr_merge_enabled boolean DEFAULT false,
+      post_merge_watch_minutes integer DEFAULT 0,
+      auto_revert_enabled boolean DEFAULT false,
       release_after_run boolean DEFAULT false,
       issue_auto_branch boolean DEFAULT true,
       last_push_error text,

--- a/__tests__/lib/scheduling.test.ts
+++ b/__tests__/lib/scheduling.test.ts
@@ -23,6 +23,8 @@ async function applyProjectsSchema(handle: TestDbHandle): Promise<void> {
     auto_commit_enabled boolean DEFAULT false,
     auto_push_enabled boolean DEFAULT false,
     auto_pr_merge_enabled boolean DEFAULT false,
+    post_merge_watch_minutes integer DEFAULT 0,
+    auto_revert_enabled boolean DEFAULT false,
     release_after_run boolean DEFAULT false,
     issue_auto_branch boolean DEFAULT true,
     last_push_error text,

--- a/__tests__/lib/start-soak.test.ts
+++ b/__tests__/lib/start-soak.test.ts
@@ -1,0 +1,184 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+vi.hoisted(() => {
+  // 1ms poll interval so the in-loop sleeps don't slow the suite.
+  process.env.TAMTAM_SOAK_POLL_MS = '1';
+});
+
+const mocks = vi.hoisted(() => ({
+  execMock: vi.fn(),
+}));
+
+vi.mock('@/lib/shared/shell', () => ({ exec: mocks.execMock }));
+
+describe('start-soak — pure helpers', () => {
+  beforeEach(() => {
+    mocks.execMock.mockReset();
+  });
+
+  it('classifies CI as `none` when the run list is empty', async () => {
+    const { classifyDefaultBranchCi } = await import('@/lib/pipeline/start-soak');
+    expect(classifyDefaultBranchCi([])).toEqual({ kind: 'none' });
+  });
+
+  it('classifies CI as `pass` when every run completed successfully', async () => {
+    const { classifyDefaultBranchCi } = await import('@/lib/pipeline/start-soak');
+    const v = classifyDefaultBranchCi([
+      { status: 'completed', conclusion: 'success' },
+      { status: 'completed', conclusion: 'skipped' },
+    ]);
+    expect(v).toEqual({ kind: 'pass' });
+  });
+
+  it('classifies CI as `pending` when at least one run is still running', async () => {
+    const { classifyDefaultBranchCi } = await import('@/lib/pipeline/start-soak');
+    const v = classifyDefaultBranchCi([
+      { status: 'completed', conclusion: 'success' },
+      { status: 'in_progress', conclusion: null },
+    ]);
+    expect(v).toEqual({ kind: 'pending' });
+  });
+
+  it('classifies CI as `fail` when any completed run failed', async () => {
+    const { classifyDefaultBranchCi } = await import('@/lib/pipeline/start-soak');
+    const v = classifyDefaultBranchCi([
+      { status: 'completed', conclusion: 'success' },
+      { status: 'completed', conclusion: 'failure', workflowName: 'tests' },
+    ]);
+    expect(v.kind).toBe('fail');
+    if (v.kind === 'fail') {
+      expect(v.failed.map((r) => r.workflowName)).toEqual(['tests']);
+    }
+  });
+
+  it('produces a deterministic, short revert branch name', async () => {
+    const { revertBranchName } = await import('@/lib/pipeline/start-soak');
+    const sha = '0123456789abcdef0123456789abcdef01234567';
+    expect(revertBranchName(sha)).toBe('revert/0123456789ab');
+    // Same sha → same branch (idempotent across soak retries).
+    expect(revertBranchName(sha)).toBe(revertBranchName(sha));
+  });
+
+  it('builds a revert PR body that mentions the merge sha + failed workflows', async () => {
+    const { buildRevertPrBody } = await import('@/lib/pipeline/start-soak');
+    const body = buildRevertPrBody(
+      {
+        mergeSha: 'deadbeef',
+        prRepo: 'owner/repo',
+        prNumber: 42,
+        prUrl: 'https://github.com/owner/repo/pull/42',
+        defaultBranch: 'main',
+        watchMinutes: 20,
+        autoRevert: false,
+      },
+      [
+        { status: 'completed', conclusion: 'failure', workflowName: 'tests', url: 'https://gha/1' },
+      ],
+    );
+    expect(body).toContain('deadbeef');
+    expect(body).toContain('tests');
+    expect(body).toContain('https://gha/1');
+    expect(body).toContain('20 minute');
+    expect(body).toContain('https://github.com/owner/repo/pull/42');
+  });
+});
+
+describe('start-soak — queryDefaultBranchCi', () => {
+  beforeEach(() => {
+    mocks.execMock.mockReset();
+  });
+
+  it('returns an empty list when gh fails', async () => {
+    mocks.execMock.mockResolvedValueOnce({ exitCode: 1, stdout: '', stderr: 'boom' });
+    const { queryDefaultBranchCi } = await import('@/lib/pipeline/start-soak');
+    const runs = await queryDefaultBranchCi({
+      projPath: '/repo',
+      repo: 'owner/repo',
+      defaultBranch: 'main',
+      mergeSha: 'deadbeef',
+    });
+    expect(runs).toEqual([]);
+  });
+
+  it('returns an empty list when gh stdout is not valid JSON', async () => {
+    mocks.execMock.mockResolvedValueOnce({ exitCode: 0, stdout: 'not json', stderr: '' });
+    const { queryDefaultBranchCi } = await import('@/lib/pipeline/start-soak');
+    const runs = await queryDefaultBranchCi({
+      projPath: '/repo',
+      repo: 'owner/repo',
+      defaultBranch: 'main',
+      mergeSha: 'deadbeef',
+    });
+    expect(runs).toEqual([]);
+  });
+
+  it('parses the gh JSON payload into CiRun rows', async () => {
+    mocks.execMock.mockResolvedValueOnce({
+      exitCode: 0,
+      stdout: JSON.stringify([
+        { status: 'completed', conclusion: 'success', url: 'u1', workflowName: 'ci', databaseId: 1 },
+        { status: 'in_progress', conclusion: null, url: 'u2', workflowName: 'slow', databaseId: 2 },
+      ]),
+      stderr: '',
+    });
+    const { queryDefaultBranchCi, classifyDefaultBranchCi } = await import('@/lib/pipeline/start-soak');
+    const runs = await queryDefaultBranchCi({
+      projPath: '/repo',
+      repo: 'owner/repo',
+      defaultBranch: 'main',
+      mergeSha: 'deadbeef',
+    });
+    expect(runs).toHaveLength(2);
+    expect(classifyDefaultBranchCi(runs).kind).toBe('pending');
+  });
+});
+
+describe('start-soak — soak verdict flow', () => {
+  beforeEach(() => {
+    mocks.execMock.mockReset();
+  });
+
+  it('classifies the happy path as pass when every run completes successfully', async () => {
+    const { classifyDefaultBranchCi } = await import('@/lib/pipeline/start-soak');
+    const v = classifyDefaultBranchCi([
+      { status: 'completed', conclusion: 'success' },
+      { status: 'completed', conclusion: 'neutral' },
+    ]);
+    expect(v.kind).toBe('pass');
+  });
+
+  it('classifies the fail path with the offending runs preserved for the revert PR body', async () => {
+    const { classifyDefaultBranchCi, buildRevertPrBody } = await import('@/lib/pipeline/start-soak');
+    const v = classifyDefaultBranchCi([
+      { status: 'completed', conclusion: 'failure', workflowName: 'tests' },
+      { status: 'completed', conclusion: 'success' },
+    ]);
+    expect(v.kind).toBe('fail');
+    if (v.kind !== 'fail') return;
+    const body = buildRevertPrBody(
+      {
+        mergeSha: 'abc1234',
+        prRepo: 'owner/repo',
+        prNumber: 1,
+        prUrl: 'https://github.com/owner/repo/pull/1',
+        defaultBranch: 'main',
+        watchMinutes: 5,
+        autoRevert: true,
+      },
+      v.failed,
+    );
+    expect(body).toContain('tests');
+    expect(body).toContain('abc1234');
+  });
+
+  it('classifies the timeout path: pending runs leave the watcher waiting until the deadline', async () => {
+    // The timeout itself is enforced by the workflow phase (deadlineAt). Here we
+    // just verify the classifier reports `pending` so the workflow loop keeps
+    // polling instead of treating partial CI as a green/red verdict.
+    const { classifyDefaultBranchCi } = await import('@/lib/pipeline/start-soak');
+    const v = classifyDefaultBranchCi([
+      { status: 'queued', conclusion: null },
+    ]);
+    expect(v.kind).toBe('pending');
+  });
+});

--- a/__tests__/lib/workflows/decide-next-phase.test.ts
+++ b/__tests__/lib/workflows/decide-next-phase.test.ts
@@ -195,6 +195,52 @@ describe('decideNextPhase', () => {
         });
       },
     );
+
+    it('soak → done regardless of exit code', () => {
+      expect(decideNextPhase({ kind: 'soak', exitCode: 0, verdict: null }))
+        .toEqual({ next: 'done', from: 'soak' });
+      expect(decideNextPhase({ kind: 'soak', exitCode: 1, verdict: null }))
+        .toEqual({ next: 'done', from: 'soak' });
+    });
+  });
+
+  describe('pr-wait → soak', () => {
+    const soak = {
+      mergeSha: 'deadbeef1234',
+      prNumber: 7,
+      prRepo: 'owner/repo',
+      prUrl: 'https://github.com/owner/repo/pull/7',
+      defaultBranch: 'main',
+      watchMinutes: 15,
+      autoRevert: false,
+    };
+
+    it('pr-wait exit 0 + soakContext present → soak', () => {
+      expect(decideNextPhase({
+        kind: 'pr-wait',
+        exitCode: 0,
+        verdict: null,
+        soakContext: soak,
+      })).toEqual({ next: 'soak', from: 'pr-wait', soak });
+    });
+
+    it('pr-wait exit 0 + soakContext absent → done', () => {
+      expect(decideNextPhase({
+        kind: 'pr-wait',
+        exitCode: 0,
+        verdict: null,
+        soakContext: null,
+      })).toEqual({ next: 'done', from: 'pr-wait' });
+    });
+
+    it('pr-wait exit nonzero + soakContext present → done (no soak after failed merge)', () => {
+      expect(decideNextPhase({
+        kind: 'pr-wait',
+        exitCode: 1,
+        verdict: null,
+        soakContext: soak,
+      })).toEqual({ next: 'done', from: 'pr-wait' });
+    });
   });
 
   describe('mark-dod → pr-wait under auto-merge', () => {

--- a/__tests__/lib/workflows/pipeline-spec.test.ts
+++ b/__tests__/lib/workflows/pipeline-spec.test.ts
@@ -11,7 +11,7 @@ import { decideNextPhase, type DecisionInputs } from '@/lib/workflows/decide-nex
 // fail at runtime — catch it here at test time instead.
 
 const DISPATCHABLE_PHASES = new Set([
-  'test', 'review', 'fix', 'commit', 'push', 'mark-dod', 'pr-wait',
+  'test', 'review', 'fix', 'commit', 'push', 'mark-dod', 'pr-wait', 'soak',
 ]);
 const TERMINAL_NAMES = new Set(['done', 'abort', 'unknown']);
 const EXTERNAL_PHASES = new Set(['fix-ci']);

--- a/app/api/jobs/notifications/route.ts
+++ b/app/api/jobs/notifications/route.ts
@@ -46,7 +46,7 @@ export async function GET() {
   // and PIPELINE_STEP_KINDS: it is not a standard release-chain step that the
   // orchestrator schedules, and the UI groups it as a top-level entry rather
   // than nesting it under a release card.
-  const PIPELINE_LIKE = new Set(['release', 'test', 'review', 'fix', 'fix-ci', 'commit', 'push', 'pr-wait', 'mark-dod']);
+  const PIPELINE_LIKE = new Set(['release', 'test', 'review', 'fix', 'fix-ci', 'commit', 'push', 'pr-wait', 'mark-dod', 'soak']);
   // mark-dod is advisory and can be followed by commit/push, so it must not
   // clear older failures on its own. Neither should intermediate green steps
   // like a passing test or LGTM review: those are step-local successes, not a

--- a/app/api/projects/by-project/[projectName]/config/route.ts
+++ b/app/api/projects/by-project/[projectName]/config/route.ts
@@ -78,6 +78,8 @@ export async function GET(
     auto_commit_enabled: testCfg?.autoCommitEnabled ?? false,
     auto_push_enabled: testCfg?.autoPushEnabled ?? false,
     auto_pr_merge_enabled: testCfg?.autoPrMergeEnabled ?? false,
+    post_merge_watch_minutes: testCfg?.postMergeWatchMinutes ?? 0,
+    auto_revert_enabled: testCfg?.autoRevertEnabled ?? false,
     release_after_run: testCfg?.releaseAfterRun ?? false,
     issue_auto_branch: testCfg?.issueAutoBranch ?? true,
     tests_disabled: testCfg?.testsDisabled ?? false,
@@ -170,7 +172,7 @@ export async function PATCH(
   // `.tamtam/config.yml` doesn't change underneath them.
   const booleanFields = [
     'test_cron_enabled', 'auto_commit_enabled', 'auto_push_enabled',
-    'auto_pr_merge_enabled', 'release_after_run',
+    'auto_pr_merge_enabled', 'auto_revert_enabled', 'release_after_run',
     'tests_disabled', 'review_disabled', 'issue_auto_branch',
   ] as const;
 
@@ -182,6 +184,23 @@ export async function PATCH(
       touched = true;
       dbUpdates.push({ field, value: body[field] ? '1' : '0' });
     }
+  }
+
+  // Soak window minutes — 0 disables the watcher, positive integers enable.
+  if (body.post_merge_watch_minutes !== undefined) {
+    const raw = body.post_merge_watch_minutes;
+    let parsed: number | null = null;
+    if (typeof raw === 'number' && Number.isFinite(raw)) parsed = Math.trunc(raw);
+    else if (typeof raw === 'string') {
+      const trimmed = raw.trim();
+      if (trimmed === '') parsed = 0;
+      else if (/^\d+$/.test(trimmed)) parsed = Number.parseInt(trimmed, 10);
+    }
+    if (parsed === null || parsed < 0) {
+      return badRequest('post_merge_watch_minutes must be a non-negative integer');
+    }
+    touched = true;
+    dbUpdates.push({ field: 'post_merge_watch_minutes', value: String(parsed) });
   }
 
   // Per-project website URL the QA agent browses. DB-only metadata.

--- a/app/api/projects/by-project/[projectName]/release/[releaseId]/route.ts
+++ b/app/api/projects/by-project/[projectName]/release/[releaseId]/route.ts
@@ -3,7 +3,7 @@ import { listJobs, getVerdict, readLog } from '@/lib/jobs/job-storage';
 import { exec } from '@/lib/shared/shell';
 import { resolveProjectPath } from '@/lib/shared/project-data';
 
-const PIPELINE_STEP_KINDS = ['test', 'review', 'fix', 'commit', 'push', 'pr-wait', 'mark-dod'];
+const PIPELINE_STEP_KINDS = ['test', 'review', 'fix', 'commit', 'push', 'pr-wait', 'mark-dod', 'soak'];
 
 function jobStatus(job: { abortedAt?: number | null; finishedAt: number | null }): 'running' | 'done' | 'aborted' {
   if (job.abortedAt != null) return 'aborted';

--- a/app/api/settings/board-resync/route.ts
+++ b/app/api/settings/board-resync/route.ts
@@ -26,7 +26,7 @@ export async function POST(request: NextRequest) {
   // child jobs (test/review/fix/commit/push/...) are routed to their release
   // root by syncJobToProjectBoard, so syncing them directly would just be
   // redundant queue work — skip them here.
-  const childKinds = new Set(['test', 'review', 'fix', 'fix-ci', 'commit', 'push', 'mark-dod', 'pr-wait']);
+  const childKinds = new Set(['test', 'review', 'fix', 'fix-ci', 'commit', 'push', 'mark-dod', 'pr-wait', 'soak']);
   // Newest jobs first so the budget gets spent on the most recent state.
   const jobs = listJobs()
     .filter((job) => {

--- a/components/ProjectDetailPage.tsx
+++ b/components/ProjectDetailPage.tsx
@@ -80,6 +80,8 @@ export function ProjectDetailPage({
   const [autoCommitEnabledInput, setAutoCommitEnabledInput] = useState(false)
   const [autoPushEnabledInput, setAutoPushEnabledInput] = useState(false)
   const [autoPrMergeEnabledInput, setAutoPrMergeEnabledInput] = useState(false)
+  const [postMergeWatchMinutesInput, setPostMergeWatchMinutesInput] = useState('')
+  const [autoRevertEnabledInput, setAutoRevertEnabledInput] = useState(false)
   const [releaseAfterRunInput, setReleaseAfterRunInput] = useState(false)
   const [issueAutoBranchInput, setIssueAutoBranchInput] = useState(true)
   const [testsDisabledInput, setTestsDisabledInput] = useState(false)
@@ -200,6 +202,10 @@ export function ProjectDetailPage({
     setAutoCommitEnabledInput(!!data.auto_commit_enabled)
     setAutoPushEnabledInput(!!data.auto_push_enabled)
     setAutoPrMergeEnabledInput(!!data.auto_pr_merge_enabled)
+    setPostMergeWatchMinutesInput(
+      data.post_merge_watch_minutes != null ? String(data.post_merge_watch_minutes) : '0',
+    )
+    setAutoRevertEnabledInput(!!data.auto_revert_enabled)
     setReleaseAfterRunInput(!!data.release_after_run)
     setIssueAutoBranchInput(data.issue_auto_branch ?? true)
     setTestsDisabledInput(!!data.tests_disabled)
@@ -306,7 +312,7 @@ export function ProjectDetailPage({
     .filter(j => j.kind === 'test' && j.status === 'done')
     .sort((a, b) => (b.finished_at || 0) - (a.finished_at || 0))[0]
 
-  const RELEASE_CHILD_KINDS = new Set(['test', 'review', 'fix', 'commit', 'push', 'mark-dod', 'pr-wait'])
+  const RELEASE_CHILD_KINDS = new Set(['test', 'review', 'fix', 'commit', 'push', 'mark-dod', 'pr-wait', 'soak'])
   const running = projectJobs.filter(j => j.status === 'running')
   const releaseRunning = running.some(j => j.kind === 'release')
   const runningJobs = (releaseRunning ? running.filter(j => !RELEASE_CHILD_KINDS.has(j.kind)) : running)
@@ -482,6 +488,8 @@ export function ProjectDetailPage({
     auto_commit_enabled: autoCommitEnabledInput,
     auto_push_enabled: autoPushEnabledInput,
     auto_pr_merge_enabled: autoPrMergeEnabledInput,
+    post_merge_watch_minutes: postMergeWatchMinutesInput,
+    auto_revert_enabled: autoRevertEnabledInput,
     release_after_run: releaseAfterRunInput,
     issue_auto_branch: issueAutoBranchInput,
     tests_disabled: testsDisabledInput,
@@ -518,6 +526,8 @@ export function ProjectDetailPage({
     configInputs.auto_commit_enabled !== !!config.auto_commit_enabled ||
     configInputs.auto_push_enabled !== !!config.auto_push_enabled ||
     configInputs.auto_pr_merge_enabled !== !!config.auto_pr_merge_enabled ||
+    configInputs.post_merge_watch_minutes !== String(config.post_merge_watch_minutes ?? 0) ||
+    configInputs.auto_revert_enabled !== !!config.auto_revert_enabled ||
     configInputs.release_after_run !== !!config.release_after_run ||
     configInputs.issue_auto_branch !== (config.issue_auto_branch ?? true) ||
     configInputs.tests_disabled !== !!config.tests_disabled ||
@@ -786,6 +796,10 @@ export function ProjectDetailPage({
             setAutoPushEnabledInput={setAutoPushEnabledInput}
             autoPrMergeEnabledInput={autoPrMergeEnabledInput}
             setAutoPrMergeEnabledInput={setAutoPrMergeEnabledInput}
+            postMergeWatchMinutesInput={postMergeWatchMinutesInput}
+            setPostMergeWatchMinutesInput={setPostMergeWatchMinutesInput}
+            autoRevertEnabledInput={autoRevertEnabledInput}
+            setAutoRevertEnabledInput={setAutoRevertEnabledInput}
             releaseAfterRunInput={releaseAfterRunInput}
             setReleaseAfterRunInput={setReleaseAfterRunInput}
             issueAutoBranchInput={issueAutoBranchInput}

--- a/components/project-detail/ConfigTab.tsx
+++ b/components/project-detail/ConfigTab.tsx
@@ -44,6 +44,10 @@ export interface ConfigTabProps {
   setAutoPushEnabledInput: (v: boolean) => void
   autoPrMergeEnabledInput: boolean
   setAutoPrMergeEnabledInput: (v: boolean) => void
+  postMergeWatchMinutesInput: string
+  setPostMergeWatchMinutesInput: (v: string) => void
+  autoRevertEnabledInput: boolean
+  setAutoRevertEnabledInput: (v: boolean) => void
   releaseAfterRunInput: boolean
   setReleaseAfterRunInput: (v: boolean) => void
   issueAutoBranchInput: boolean
@@ -91,6 +95,10 @@ export function ConfigTab({
   setAutoPushEnabledInput,
   autoPrMergeEnabledInput,
   setAutoPrMergeEnabledInput,
+  postMergeWatchMinutesInput,
+  setPostMergeWatchMinutesInput,
+  autoRevertEnabledInput,
+  setAutoRevertEnabledInput,
   releaseAfterRunInput,
   setReleaseAfterRunInput,
   issueAutoBranchInput,
@@ -332,6 +340,8 @@ export function ConfigTab({
                 auto_commit_enabled: autoCommitEnabledInput,
                 auto_push_enabled: autoPushEnabledInput,
                 auto_pr_merge_enabled: autoPrMergeEnabledInput,
+                post_merge_watch_minutes: Number.parseInt(postMergeWatchMinutesInput, 10) || 0,
+                auto_revert_enabled: autoRevertEnabledInput,
               },
               setters: {
                 setAutoCommit: setAutoCommitEnabledInput,
@@ -464,6 +474,40 @@ export function ConfigTab({
             />
             <p className="text-xs text-text-tertiary mt-1">Project-specific style guide for auto-generated commit messages. Committed to <span className="font-mono">.tamtam/config.yml</span>; falls back to the global setting when empty.</p>
           </div>
+        </div>
+
+        {/* Post-merge soak window */}
+        <div className="px-4 py-3 border-t border-border space-y-3">
+          <div>
+            <label className="block font-medium text-xs text-text-secondary mb-1" htmlFor="post-merge-watch-minutes">
+              Post-merge watch (minutes)
+            </label>
+            <input
+              id="post-merge-watch-minutes"
+              type="text"
+              inputMode="numeric"
+              className="w-full px-3 py-1.5 text-sm bg-bg-primary border border-border rounded-md text-text-primary font-mono focus:outline-none focus:ring-2 focus:ring-accent/30 focus:border-accent transition-colors placeholder:text-text-tertiary"
+              value={postMergeWatchMinutesInput}
+              onChange={(e) => setPostMergeWatchMinutesInput(e.target.value)}
+              placeholder="0"
+            />
+            <p className="text-xs text-text-tertiary mt-1">
+              After PR merge, watch default-branch CI on the merge commit for this many minutes. Failures inside the window open a revert PR. <code className="font-mono">0</code> disables the watcher.
+            </p>
+          </div>
+          <label className="flex items-start gap-2 cursor-pointer select-none">
+            <input
+              id="auto-revert-enabled"
+              type="checkbox"
+              className="w-4 h-4 accent-accent mt-0.5 shrink-0 cursor-pointer"
+              checked={autoRevertEnabledInput}
+              onChange={(e) => setAutoRevertEnabledInput(e.target.checked)}
+            />
+            <div className="flex-1 min-w-0">
+              <div className="font-medium text-sm text-text-primary">Auto-merge revert PR</div>
+              <div className="text-xs text-text-tertiary">When the watcher opens a revert PR, also enable squash auto-merge. Off = the revert PR stays open for human review.</div>
+            </div>
+          </label>
         </div>
 
         {/* Trigger cadence */}

--- a/components/project-detail/OverviewTab.tsx
+++ b/components/project-detail/OverviewTab.tsx
@@ -79,6 +79,7 @@ export function OverviewTab({
       push: 0,
       'mark-dod': 0,
       'pr-wait': 0,
+      soak: 0,
       agent: 0,
       other: 0,
     } satisfies Record<KindBucket, number>,

--- a/components/project-detail/PipelineStrip.tsx
+++ b/components/project-detail/PipelineStrip.tsx
@@ -36,7 +36,7 @@ export interface PipelineStripProps {
   onRefresh: () => Promise<void>
 }
 
-const PIPELINE_KINDS = new Set(['test', 'review', 'fix', 'commit', 'push', 'mark-dod', 'pr-wait'])
+const PIPELINE_KINDS = new Set(['test', 'review', 'fix', 'commit', 'push', 'mark-dod', 'pr-wait', 'soak'])
 
 interface PipelineChainContext {
   releaseId: string | null
@@ -137,6 +137,7 @@ function connectorClass(prev: StepState): string {
 function jobKindLabel(kind: string): string {
   if (kind === 'mark-dod') return 'dod'
   if (kind === 'pr-wait') return 'merge'
+  if (kind === 'soak') return 'soak'
   return kind.replace(/-/g, ':')
 }
 
@@ -281,6 +282,7 @@ export function PipelineStrip({
   const pushJob = latestOfKind('push')
   const dodJob = latestOfKind('mark-dod')
   const prWaitJob = latestOfKind('pr-wait')
+  const soakJob = latestOfKind('soak')
   const latestProjectReview = projectJobs
     .filter((job) => job.kind === 'review' && job.status === 'done' && !!job.verdict)
     .sort((a, b) => (b.finished_at || 0) - (a.finished_at || 0))[0]
@@ -569,6 +571,15 @@ export function PipelineStrip({
   }
   if (prWaitJob) {
     steps.push({ label: 'merge', state: prWaitState, hint: prWaitHint, action: prWaitAction, jobId: prWaitJob.id })
+  }
+  if (soakJob) {
+    const soakState = stateOf(soakJob)
+    const soakHint = soakJob.status === 'running'
+      ? 'watching default-branch CI on the merge commit — click to open terminal'
+      : soakJob.exit_code === 0
+        ? 'soak completed — no failures observed'
+        : 'soak detected post-merge failures and opened a revert PR — click to view log'
+    steps.push({ label: 'soak', state: soakState, hint: soakHint, action: openJob(soakJob), jobId: soakJob.id })
   }
 
   const runningStepIdx = steps.findIndex(s => s.state === 'running')

--- a/components/project-runs/utils.ts
+++ b/components/project-runs/utils.ts
@@ -116,6 +116,7 @@ export type KindBucket =
   | 'push'
   | 'mark-dod'
   | 'pr-wait'
+  | 'soak'
   | 'agent'
   | 'other'
 
@@ -130,6 +131,7 @@ export const ACTIVE_WORK_BUCKET_ORDER: KindBucket[] = [
   'push',
   'mark-dod',
   'pr-wait',
+  'soak',
   'agent',
   'other',
 ]
@@ -145,6 +147,7 @@ export function bucketOf(kind: string): KindBucket {
   if (kind === 'push') return 'push'
   if (kind === 'mark-dod') return 'mark-dod'
   if (kind === 'pr-wait') return 'pr-wait'
+  if (kind === 'soak') return 'soak'
   if (kind.startsWith('agent:')) return 'agent'
   return 'other'
 }
@@ -160,6 +163,7 @@ export const KIND_LABEL: Record<KindBucket, string> = {
   push: 'push',
   'mark-dod': 'dod',
   'pr-wait': 'pr-wait',
+  soak: 'soak',
   agent: 'agent',
   other: 'action',
 }
@@ -175,6 +179,7 @@ export const KIND_COLOR: Record<KindBucket, string> = {
   push: 'bg-status-success/15 text-status-success',
   'mark-dod': 'bg-status-info/15 text-status-info',
   'pr-wait': 'bg-status-info/15 text-status-info',
+  soak: 'bg-status-info/15 text-status-info',
   agent: 'bg-bg-tertiary text-text-secondary border border-border',
   other: 'bg-text-tertiary/15 text-text-secondary',
 }
@@ -187,7 +192,7 @@ export function activeWorkBadgeLabel(kindOrBucket: string): string {
 export function activeWorkAccentClass(kind: string): string {
   const bucket = bucketOf(kind)
   if (bucket === 'run' || bucket === 'release') return 'border-l-accent'
-  if (bucket === 'review' || bucket === 'mark-dod' || bucket === 'pr-wait') return 'border-l-status-info'
+  if (bucket === 'review' || bucket === 'mark-dod' || bucket === 'pr-wait' || bucket === 'soak') return 'border-l-status-info'
   if (bucket === 'test' || bucket === 'commit' || bucket === 'push') return 'border-l-status-success'
   if (bucket === 'fix' || bucket === 'fix-ci') return 'border-l-status-warning'
   return 'border-l-border'
@@ -206,7 +211,7 @@ export function activeWorkTitle(job: JobInfo): string {
 // step, so the UI shows it as a top-level row rather than nesting it under a
 // release card. It IS included in PIPELINE_LIKE in the notifications route so
 // that a terminal release success can supersede an older fix-ci failure.
-export const PIPELINE_CHILD_KINDS = new Set(['test', 'review', 'fix', 'commit', 'push', 'mark-dod', 'pr-wait'])
+export const PIPELINE_CHILD_KINDS = new Set(['test', 'review', 'fix', 'commit', 'push', 'mark-dod', 'pr-wait', 'soak'])
 
 // An entry represents a single row in the history. For `run` jobs with a
 // session_id we collapse every turn of the conversation into one entry so the
@@ -939,6 +944,7 @@ export function buildReleaseSummary(children: Entry[], release?: Entry): string 
 function pipelineStepLabel(kind: string): string {
   if (kind === 'mark-dod') return 'dod'
   if (kind === 'pr-wait') return 'pr wait'
+  if (kind === 'soak') return 'soak'
   return kind
 }
 

--- a/docs/PIPELINE.md
+++ b/docs/PIPELINE.md
@@ -1,6 +1,8 @@
 # Release Pipeline — How It Works
 
-The pipeline is a quality-gated sequence driven by the selected provider. The registry is unified per project: `test → review → fix → commit → push → dod → merge`.
+The pipeline is a quality-gated sequence driven by the selected provider. The registry is unified per project: `test → review → fix → commit → push → dod → merge → soak`.
+
+`soak` is opt-in: when the project's `post_merge_watch_minutes` is `0` (the default), the chain still ends at `merge` and the release is finalised. When it is positive, TamTam keeps watching the default branch's CI on the merge commit for that window. A default-branch CI failure inside the window opens a revert PR (and auto-merges it when `auto_revert_enabled` is on).
 
 ## Auto-fix policy (requirements)
 
@@ -199,8 +201,19 @@ landed. If auto-merge is enabled and the push produced or reused a PR, TamTam
 still continues into `pr-wait` even when `mark-dod` exits nonzero.
 
 PR-MERGE-WAIT
-  ├─ CI passes → merge PR → switch to default branch → finalize release (exit 0)
+  ├─ CI passes → merge PR → switch to default branch
+  │              ├─ project has post_merge_watch_minutes > 0 → start SOAK
+  │              └─ otherwise                                 → finalize release (exit 0)
   └─ CI fails  → seed failed CI URL → dispatch fix-ci → finalize release (exit 1)
+
+SOAK
+  ├─ default-branch CI on merge sha passes within window → finalize release (exit 0)
+  ├─ default-branch CI on merge sha fails within window  → open revert PR
+  │     ├─ auto_revert_enabled → enable squash auto-merge on the revert PR
+  │     └─ otherwise           → leave revert PR open for review
+  │     emit `post_merge_revert` notification (success | failure)
+  │     finalize release (exit 1)
+  └─ window elapsed with no failures → finalize release (exit 0)
 
 `pr-wait` polls the PR immediately, then every 30 seconds by default. When
 GitHub reports an empty `statusCheckRollup`, TamTam does not treat that as "no
@@ -398,6 +411,8 @@ All stored in the `projects` DB table; editable via the project Config tab.
 | `auto_pr_merge_enabled` | off | After DoD, poll CI and auto-merge the PR when the push path produced a PR |
 | `release_after_run` | off | Trigger the full pipeline automatically after each successful agent/terminal run |
 | `review_disabled` | off | Skip the review phase; after tests pass, uncommitted changes go to commit and unpushed commits go to push |
+| `post_merge_watch_minutes` | 0 | After merge, watch default-branch CI on the merge commit for this many minutes. 0 disables. A failure inside the window opens a revert PR via `git revert <sha>` + `gh pr create` |
+| `auto_revert_enabled` | off | When the soak watcher opens a revert PR, also enable squash auto-merge so it lands without human review |
 
 When `auto_push_enabled` is **off**: pipeline chaining only happens during an active Release run.
 When `auto_push_enabled` is **on**: the same review→fix→push chaining happens for any standalone review job on that project.
@@ -425,6 +440,7 @@ Checks the push job log for strings from husky, lint-staged, eslint, pre-commit 
 | `lib/start-push.ts` | `startProjectPush(project)` | git add → commit message → push |
 | `lib/pipeline/push-rejection.ts` | `isHookRejection`, `isTestFailureRejection` | Classifies push failure kind |
 | `lib/start-mark-dod.ts` | `startMarkDod(project)` | DoD verification against the linked issue or PR, with checkbox updates when issue criteria exist |
+| `lib/pipeline/start-soak.ts` | `launchSoak`, `classifyDefaultBranchCi`, `openRevertPr`, `notifyPostMergeRevert` | Post-merge CI watcher + revert-PR opener. Pure helpers are unit-tested; the side-effectful loop is driven by `lib/workflows/phases/soak-phase.ts` |
 | `lib/job-storage.ts` | `markDone(jobId, exitCode)` | Called by PM2 exit handler; triggers all completion hooks |
 
 ---
@@ -617,7 +633,7 @@ releaseWorkflow         (lib/workflows/release.ts)
 HTTP response with release.jobId
 ```
 
-### The 8 phase workflows
+### The 9 phase workflows
 
 Each follows the same kickoff/await/return shape (with minor variations: push/commit are inline so they have no await step; review has an extra verdict-read step; pr-wait has a 60-min wait ceiling). All under `lib/workflows/phases/`:
 
@@ -631,6 +647,7 @@ Each follows the same kickoff/await/return shape (with minor variations: push/co
 | `commit` | `commit-phase.ts` | `CommitPhaseResult` — `{ commitSha, message, jobId? }` |
 | `mark-dod` | `mark-dod-phase.ts` | `MarkDodPhaseResult` — `{ jobId, issueNumber, verified, total, changed }` |
 | `pr-wait` | `pr-wait-phase.ts` | `PrWaitPhaseResult` — `{ jobId, finished, merged, reason, exitCode }` |
+| `soak` | `soak-phase.ts` | `SoakPhaseResult` — `{ jobId, verdict, revertPrUrl, autoMerged }` (or `{ skipped: true, reason }`) |
 
 All seven return discriminated unions with `ok: true | false` and a `reason` for the failure branch (`start_failed` / `launch_failed` / `mark_dod_failed`). Each has a focused unit test file with directive-source guards. The push-hook fix path no longer has its own phase — hook rejections spawn the generic `fix` phase with `parentJobId` pointing at the failed push.
 
@@ -710,5 +727,6 @@ Any `Date.now()`, `Math.random()`, settings read, env read, or branch-state read
 | `lib/workflows/dispatch-phase.ts` | NextPhase → start(matching phase workflow) |
 | `lib/workflows/find-next-substep.ts` | Sibling-job matcher for observation-only mode |
 | `lib/workflows/decode-workflow-payload.ts` | CBOR + devalue payload decoder for the API |
-| `lib/workflows/phases/*.ts` | 8 per-phase driver workflows |
+| `lib/workflows/phases/*.ts` | 9 per-phase driver workflows |
+| `lib/pipeline/start-soak.ts` | Soak-phase pure helpers (`classifyDefaultBranchCi`, `revertBranchName`, `buildRevertPrBody`) plus side-effectful `queryDefaultBranchCi`, `openRevertPr`, `autoMergeRevertPr`, `notifyPostMergeRevert`, `launchSoak` |
 | `__tests__/lib/workflows/*.test.ts` | ~140 unit tests with directive guards |

--- a/lib/client/projects.ts
+++ b/lib/client/projects.ts
@@ -448,6 +448,8 @@ export async function updateProjectConfig(
     auto_commit_enabled?: boolean
     auto_push_enabled?: boolean
     auto_pr_merge_enabled?: boolean
+    post_merge_watch_minutes?: string
+    auto_revert_enabled?: boolean
     release_after_run?: boolean
     issue_auto_branch?: boolean
     tests_disabled?: boolean

--- a/lib/client/types.ts
+++ b/lib/client/types.ts
@@ -139,6 +139,8 @@ export interface ProjectConfig {
   auto_commit_enabled?: boolean
   auto_push_enabled?: boolean
   auto_pr_merge_enabled?: boolean
+  post_merge_watch_minutes?: number
+  auto_revert_enabled?: boolean
   release_after_run?: boolean
   issue_auto_branch?: boolean
   tests_disabled?: boolean

--- a/lib/db/migrations/0010_left_wraith.sql
+++ b/lib/db/migrations/0010_left_wraith.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "projects" ADD COLUMN "post_merge_watch_minutes" integer DEFAULT 0;--> statement-breakpoint
+ALTER TABLE "projects" ADD COLUMN "auto_revert_enabled" boolean DEFAULT false;

--- a/lib/db/migrations/meta/0010_snapshot.json
+++ b/lib/db/migrations/meta/0010_snapshot.json
@@ -1,0 +1,1491 @@
+{
+  "id": "07a0164d-c6bd-4d1a-a768-af2b977ac3fd",
+  "prevId": "a2d4e0ee-1517-4d2e-8f10-3199d4ceb3fb",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.agents": {
+      "name": "agents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project": {
+          "name": "project",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "skill_ids": {
+          "name": "skill_ids",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'"
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'normal'"
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "schedule": {
+          "name": "schedule",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "runner": {
+          "name": "runner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pm2'"
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "doc_paths": {
+          "name": "doc_paths",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'"
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fallback_enabled": {
+          "name": "fallback_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "prerequisite_command": {
+          "name": "prerequisite_command",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.gh_issue_detail_cache": {
+      "name": "gh_issue_detail_cache",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project": {
+          "name": "project",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "number": {
+          "name": "number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fetched_at": {
+          "name": "fetched_at",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "gh_issue_detail_cache_project_number": {
+          "name": "gh_issue_detail_cache_project_number",
+          "columns": [
+            {
+              "expression": "project",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.gh_issues_cache": {
+      "name": "gh_issues_cache",
+      "schema": "",
+      "columns": {
+        "project": {
+          "name": "project",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "repo": {
+          "name": "repo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prs": {
+          "name": "prs",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'"
+        },
+        "issues": {
+          "name": "issues",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'"
+        },
+        "fetched_at": {
+          "name": "fetched_at",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.gh_status": {
+      "name": "gh_status",
+      "schema": "",
+      "columns": {
+        "project": {
+          "name": "project",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "release_tag": {
+          "name": "release_tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ci": {
+          "name": "ci",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ci_failed_url": {
+          "name": "ci_failed_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "head_sha": {
+          "name": "head_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "local_head_sha": {
+          "name": "local_head_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fetched_at": {
+          "name": "fetched_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.job_completion_events": {
+      "name": "job_completion_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "job_id": {
+          "name": "job_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "exit_code": {
+          "name": "exit_code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "project": {
+          "name": "project",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "release_id": {
+          "name": "release_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gh_issue_number": {
+          "name": "gh_issue_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "emitted_at": {
+          "name": "emitted_at",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consumed_by": {
+          "name": "consumed_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "job_completion_events_job_id": {
+          "name": "job_completion_events_job_id",
+          "columns": [
+            {
+              "expression": "job_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "job_completion_events_unconsumed": {
+          "name": "job_completion_events_unconsumed",
+          "columns": [
+            {
+              "expression": "consumed_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "emitted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.job_resource_samples": {
+      "name": "job_resource_samples",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "job_id": {
+          "name": "job_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sampled_at": {
+          "name": "sampled_at",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cpu_pct": {
+          "name": "cpu_pct",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rss_kb": {
+          "name": "rss_kb",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "job_resource_samples_job_sampled": {
+          "name": "job_resource_samples_job_sampled",
+          "columns": [
+            {
+              "expression": "job_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sampled_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.jobs": {
+      "name": "jobs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project": {
+          "name": "project",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pid": {
+          "name": "pid",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "log_path": {
+          "name": "log_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "exit_code": {
+          "name": "exit_code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "seen": {
+          "name": "seen",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cache_read_tokens": {
+          "name": "cache_read_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cache_create_tokens": {
+          "name": "cache_create_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_prompt": {
+          "name": "user_prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "context_meta": {
+          "name": "context_meta",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parent_job_id": {
+          "name": "parent_job_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gh_issue_number": {
+          "name": "gh_issue_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gh_issue_repo": {
+          "name": "gh_issue_repo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gh_issue_title": {
+          "name": "gh_issue_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "log_pruned": {
+          "name": "log_pruned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "verdict": {
+          "name": "verdict",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cost_usd": {
+          "name": "cost_usd",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "release_id": {
+          "name": "release_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aborted_at": {
+          "name": "aborted_at",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "release_deadline_at": {
+          "name": "release_deadline_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prompt_bytes": {
+          "name": "prompt_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "work_summary": {
+          "name": "work_summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "modified_files": {
+          "name": "modified_files",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.maintenance_status": {
+      "name": "maintenance_status",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notification_throttle": {
+      "name": "notification_throttle",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "last_sent_at": {
+          "name": "last_sent_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "suppressed_count": {
+          "name": "suppressed_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ollama_usage": {
+      "name": "ollama_usage",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "ts": {
+          "name": "ts",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project": {
+          "name": "project",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_kind": {
+          "name": "source_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "ollama_usage_ts": {
+          "name": "ollama_usage_ts",
+          "columns": [
+            {
+              "expression": "ts",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pipeline_lock_events": {
+      "name": "pipeline_lock_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project": {
+          "name": "project",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "released_by_job_id": {
+          "name": "released_by_job_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "emitted_at": {
+          "name": "emitted_at",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consumed_by": {
+          "name": "consumed_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "pipeline_lock_events_unconsumed": {
+          "name": "pipeline_lock_events_unconsumed",
+          "columns": [
+            {
+              "expression": "consumed_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "emitted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pipeline_locks": {
+      "name": "pipeline_locks",
+      "schema": "",
+      "columns": {
+        "project": {
+          "name": "project",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "locked_by_job_id": {
+          "name": "locked_by_job_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "acquired_at": {
+          "name": "acquired_at",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.projects": {
+      "name": "projects",
+      "schema": "",
+      "columns": {
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "github": {
+          "name": "github",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "priority": {
+          "name": "priority",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "custom_actions": {
+          "name": "custom_actions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "test_command": {
+          "name": "test_command",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tests_disabled": {
+          "name": "tests_disabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "review_disabled": {
+          "name": "review_disabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "test_cron_enabled": {
+          "name": "test_cron_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "test_cron_schedule": {
+          "name": "test_cron_schedule",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auto_commit_enabled": {
+          "name": "auto_commit_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "auto_push_enabled": {
+          "name": "auto_push_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "auto_pr_merge_enabled": {
+          "name": "auto_pr_merge_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "post_merge_watch_minutes": {
+          "name": "post_merge_watch_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "auto_revert_enabled": {
+          "name": "auto_revert_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "release_after_run": {
+          "name": "release_after_run",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "issue_auto_branch": {
+          "name": "issue_auto_branch",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "last_push_error": {
+          "name": "last_push_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_push_at": {
+          "name": "last_push_at",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "review_prompt_addendum": {
+          "name": "review_prompt_addendum",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "review_prerequisite_command": {
+          "name": "review_prerequisite_command",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fix_prompt_addendum": {
+          "name": "fix_prompt_addendum",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "website": {
+          "name": "website",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "qa_url": {
+          "name": "qa_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "archived": {
+          "name": "archived",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "paused": {
+          "name": "paused",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.queued_agent_runs": {
+      "name": "queued_agent_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project": {
+          "name": "project",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_name": {
+          "name": "agent_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "triggered_by": {
+          "name": "triggered_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'manual'"
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "enqueued_at": {
+          "name": "enqueued_at",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "queued_agent_runs_project_agent": {
+          "name": "queued_agent_runs_project_agent",
+          "columns": [
+            {
+              "expression": "project",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.recommendations": {
+      "name": "recommendations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project": {
+          "name": "project",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_kind": {
+          "name": "source_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agent_name": {
+          "name": "agent_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "detail": {
+          "name": "detail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'open'"
+        },
+        "payload": {
+          "name": "payload",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.retrieval_chunks": {
+      "name": "retrieval_chunks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "chunk_id": {
+          "name": "chunk_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project": {
+          "name": "project",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_kind": {
+          "name": "source_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chunk_index": {
+          "name": "chunk_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "vector(768)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "retrieval_chunks_chunk_id_unique": {
+          "name": "retrieval_chunks_chunk_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "chunk_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.retrieval_records": {
+      "name": "retrieval_records",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project": {
+          "name": "project",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_kind": {
+          "name": "source_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chunk_count": {
+          "name": "chunk_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "indexed_at": {
+          "name": "indexed_at",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.settings": {
+      "name": "settings",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.skills": {
+      "name": "skills",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/lib/db/migrations/meta/_journal.json
+++ b/lib/db/migrations/meta/_journal.json
@@ -71,6 +71,13 @@
       "when": 1779085485570,
       "tag": "0009_small_vindicator",
       "breakpoints": true
+    },
+    {
+      "idx": 10,
+      "version": "7",
+      "when": 1779104104142,
+      "tag": "0010_left_wraith",
+      "breakpoints": true
     }
   ]
 }

--- a/lib/db/schema.ts
+++ b/lib/db/schema.ts
@@ -45,6 +45,12 @@ export const projects = pgTable('projects', {
   autoCommitEnabled: boolean('auto_commit_enabled').default(false),
   autoPushEnabled: boolean('auto_push_enabled').default(false),
   autoPrMergeEnabled: boolean('auto_pr_merge_enabled').default(false),
+  // Number of minutes after a PR merge during which TamTam watches the
+  // default branch's CI on the merge commit. 0 disables the watcher.
+  // When CI fails inside the window, a revert PR is opened (and
+  // auto-merged when `auto_revert_enabled` is also on).
+  postMergeWatchMinutes: integer('post_merge_watch_minutes').default(0),
+  autoRevertEnabled: boolean('auto_revert_enabled').default(false),
   releaseAfterRun: boolean('release_after_run').default(false),
   issueAutoBranch: boolean('issue_auto_branch').default(true),
   lastPushError: text('last_push_error'),

--- a/lib/github/project-board.ts
+++ b/lib/github/project-board.ts
@@ -470,7 +470,7 @@ export async function ensureProjectBoard(overrides?: Partial<BoardSettingsSnapsh
 }
 
 function isPipelineChild(job: JobData): boolean {
-  return ['test', 'review', 'fix', 'commit', 'push', 'mark-dod', 'pr-wait'].includes(job.kind);
+  return ['test', 'review', 'fix', 'commit', 'push', 'mark-dod', 'pr-wait', 'soak'].includes(job.kind);
 }
 
 function resolveRootJob(job: JobData): JobData | null {

--- a/lib/jobs/lifecycle.ts
+++ b/lib/jobs/lifecycle.ts
@@ -405,7 +405,7 @@ function findLinkedActiveReleaseJob(job: JobData): JobData | null {
 // runs cheaply on every markDone call and only acts when the release has
 // no running children and its most recent child finished long enough ago
 // that we're confident nothing else is about to chain.
-export const PIPELINE_STEP_KINDS = new Set(['test', 'review', 'fix', 'commit', 'push', 'pr-wait', 'mark-dod']);
+export const PIPELINE_STEP_KINDS = new Set(['test', 'review', 'fix', 'commit', 'push', 'pr-wait', 'mark-dod', 'soak']);
 
 // `reconcileStaleRelease` was retired when chain-loop closure landed: phase
 // workflows now re-dispatch the orchestrator with their sub-step jobId, and

--- a/lib/pipeline/pipeline-steps.ts
+++ b/lib/pipeline/pipeline-steps.ts
@@ -21,6 +21,8 @@ export interface StepConfigView {
   auto_commit_enabled?: boolean;
   auto_push_enabled?: boolean;
   auto_pr_merge_enabled?: boolean;
+  post_merge_watch_minutes?: number;
+  auto_revert_enabled?: boolean;
 }
 
 export interface StepSetters {
@@ -143,11 +145,23 @@ export const BUILT_IN_STEPS: PipelineStep[] = [
       ? 'Poll CI and auto-merge the PR once checks pass. Click to disable (PR stays open for manual merge).'
       : 'Poll CI and auto-merge the PR once checks pass. Click to enable (also enables commit + push).',
   },
+  {
+    id: 'soak',
+    label: 'soak',
+    mandatory: false,
+    isActive: ({ config }) => (config.post_merge_watch_minutes ?? 0) > 0,
+    description: ({ config }) => {
+      const m = config.post_merge_watch_minutes ?? 0;
+      if (m <= 0) return 'After merge, TamTam stops. Set Post-merge watch (minutes) in the Soak section to enable a CI watch window.';
+      const auto = config.auto_revert_enabled ? '; auto-merges the revert PR' : '; opens a revert PR for manual review';
+      return `Watch default-branch CI on the merge commit for ${m} min${auto}.`;
+    },
+  },
 ];
 
 // Built-in ordering — used to sort any plugin-registered steps that happen to
 // reuse a built-in id (extras with unknown ids sort after the last built-in).
-const BUILT_IN_ORDER = ['test', 'review', 'fix', 'commit', 'push', 'dod', 'merge'];
+const BUILT_IN_ORDER = ['test', 'review', 'fix', 'commit', 'push', 'dod', 'merge', 'soak'];
 
 const EXTRA_STEPS: PipelineStep[] = [];
 

--- a/lib/pipeline/start-push.ts
+++ b/lib/pipeline/start-push.ts
@@ -23,7 +23,7 @@ export type PushResult =
   | { ok: true; jobId?: string; commitSha: string; message: string; prUrl?: string; prNumber?: number; prRepo?: string }
   | { ok: false; jobId?: string; status: number; detail: string; blockingJobId?: string };
 
-const RETRIABLE_RELEASE_STEP_KINDS = new Set(['test', 'review', 'fix', 'commit', 'push', 'mark-dod', 'pr-wait']);
+const RETRIABLE_RELEASE_STEP_KINDS = new Set(['test', 'review', 'fix', 'commit', 'push', 'mark-dod', 'pr-wait', 'soak']);
 
 export type ReleaseRetryValidation =
   | { ok: true; parentJobId: string | null; releaseLinkedRetry: boolean }

--- a/lib/pipeline/start-soak.ts
+++ b/lib/pipeline/start-soak.ts
@@ -1,0 +1,374 @@
+// Post-merge soak watcher.
+//
+// After a PR merges into the default branch, TamTam can keep watching the
+// default branch's CI on the merge commit for a configurable window. If a
+// run on that commit fails inside the window, TamTam opens a revert PR via
+// `git revert <sha>` + `gh pr create`, and — when the project flag
+// `auto_revert_enabled` is on — auto-merges the revert.
+//
+// The watcher is gated by per-project `post_merge_watch_minutes`. Zero or
+// missing means "skip soak entirely", which preserves the prior behavior
+// where the release ends at PR merge.
+//
+// This module is split into two layers:
+//
+//   1. Pure helpers — `classifyDefaultBranchCi`, `revertBranchName`,
+//      `buildRevertPrBody`. These have no side effects so unit tests can
+//      cover the happy/fail/timeout decision paths without spinning up
+//      Postgres, the workflow runtime, or git.
+//
+//   2. `soakWatcher` — the side-effectful loop that polls `gh run list` on
+//      the merge SHA, opens the revert PR on failure, and fires the
+//      `post_merge_revert` notification. Driven by the workflow phase in
+//      `lib/workflows/phases/soak-phase.ts`.
+
+import { mkdirSync } from 'fs';
+import { join } from 'path';
+import { resolveProjectPath } from '@/lib/shared/project-data';
+import { getImproveConfig } from '@/lib/scheduling/scheduling';
+import { exec } from '@/lib/shared/shell';
+import { createJob, getJob, markDone, updateJob } from '@/lib/jobs/job-storage';
+import { appendRedactedFileSync } from '@/lib/jobs/redacted-log-writer';
+import type { JobData } from '@/lib/jobs/types';
+
+export const SOAK_DEFAULT_POLL_INTERVAL_MS =
+  parseInt(process.env.TAMTAM_SOAK_POLL_MS ?? '', 10) || 60_000;
+
+export interface SoakContextMeta {
+  mergeSha: string;
+  prRepo: string;
+  prNumber: number;
+  prUrl: string;
+  defaultBranch: string;
+  watchMinutes: number;
+  autoRevert: boolean;
+}
+
+export interface CiRun {
+  status: string;
+  conclusion: string | null;
+  url?: string;
+  workflowName?: string;
+  databaseId?: number | string;
+}
+
+export type SoakCiVerdict =
+  | { kind: 'pass' }
+  | { kind: 'fail'; failed: CiRun[] }
+  | { kind: 'pending' }
+  | { kind: 'none' };
+
+/**
+ * Pure helper: turn a `gh run list` payload into a soak verdict.
+ *
+ * Statuses we recognise (mirrors the GitHub Actions REST schema):
+ *   - completed + conclusion in success/skipped/neutral → counts as pass
+ *   - completed + conclusion in failure/timed_out/cancelled/startup_failure → fail
+ *   - anything not completed → pending
+ *
+ * Empty list → `none`. The caller decides whether to wait or treat that
+ * as "no CI configured".
+ */
+export function classifyDefaultBranchCi(runs: CiRun[]): SoakCiVerdict {
+  if (!runs || runs.length === 0) return { kind: 'none' };
+  const failed: CiRun[] = [];
+  let anyPending = false;
+  for (const r of runs) {
+    const status = (r.status ?? '').toLowerCase();
+    if (status !== 'completed') {
+      anyPending = true;
+      continue;
+    }
+    const conc = (r.conclusion ?? '').toLowerCase();
+    if (conc === 'success' || conc === 'skipped' || conc === 'neutral') continue;
+    failed.push(r);
+  }
+  if (failed.length > 0) return { kind: 'fail', failed };
+  if (anyPending) return { kind: 'pending' };
+  return { kind: 'pass' };
+}
+
+/**
+ * Pure helper: deterministic branch name for the revert PR. Short and
+ * predictable so two soak failures on the same merge SHA reuse the same
+ * branch instead of stacking duplicates.
+ */
+export function revertBranchName(mergeSha: string): string {
+  return `revert/${mergeSha.slice(0, 12)}`;
+}
+
+/**
+ * Pure helper: PR body for the revert. Mentions the merge SHA, the failing
+ * workflow names, and the original PR for traceability.
+ */
+export function buildRevertPrBody(meta: SoakContextMeta, failed: CiRun[]): string {
+  const lines: string[] = [];
+  lines.push(`Auto-revert opened by TamTam post-merge watcher.`);
+  lines.push('');
+  lines.push(`- Merge commit: \`${meta.mergeSha}\``);
+  lines.push(`- Source PR: ${meta.prUrl}`);
+  if (failed.length > 0) {
+    lines.push('- Failed checks on default branch:');
+    for (const f of failed) {
+      const name = f.workflowName ?? 'workflow';
+      const conc = (f.conclusion ?? 'unknown').toLowerCase();
+      const url = f.url ? ` ${f.url}` : '';
+      lines.push(`  - ${name} → ${conc}${url}`);
+    }
+  }
+  lines.push('');
+  lines.push(`Watch window: ${meta.watchMinutes} minute${meta.watchMinutes === 1 ? '' : 's'}.`);
+  return lines.join('\n');
+}
+
+interface QueryDefaultBranchCiArgs {
+  projPath: string;
+  repo: string;
+  defaultBranch: string;
+  mergeSha: string;
+}
+
+/**
+ * Side-effectful: read `gh run list` for runs on the merge commit. Returns
+ * an empty list when GitHub hasn't reported any yet (which the caller
+ * treats as "none").
+ */
+export async function queryDefaultBranchCi(args: QueryDefaultBranchCiArgs): Promise<CiRun[]> {
+  const r = await exec(
+    'gh',
+    [
+      'run', 'list',
+      '--repo', args.repo,
+      '--branch', args.defaultBranch,
+      '--commit', args.mergeSha,
+      '--limit', '20',
+      '--json', 'status,conclusion,url,workflowName,databaseId',
+    ],
+    { cwd: args.projPath, timeout: 20_000 },
+  );
+  if (r.exitCode !== 0) return [];
+  try {
+    const parsed = JSON.parse(r.stdout);
+    if (!Array.isArray(parsed)) return [];
+    return parsed
+      .map((p): CiRun => ({
+        status: typeof p?.status === 'string' ? p.status : '',
+        conclusion: typeof p?.conclusion === 'string' ? p.conclusion : null,
+        url: typeof p?.url === 'string' ? p.url : undefined,
+        workflowName: typeof p?.workflowName === 'string' ? p.workflowName : undefined,
+        databaseId: typeof p?.databaseId === 'number' ? p.databaseId : undefined,
+      }))
+      .filter((r) => r.status !== '');
+  } catch {
+    return [];
+  }
+}
+
+export interface OpenRevertPrArgs {
+  projPath: string;
+  repo: string;
+  defaultBranch: string;
+  meta: SoakContextMeta;
+  failed: CiRun[];
+  log: (s: string) => void;
+}
+
+export interface OpenRevertPrResult {
+  ok: boolean;
+  prUrl?: string;
+  branch: string;
+  error?: string;
+}
+
+/**
+ * Open (or reuse) a revert PR for the merge SHA. Best-effort:
+ *   - hard reset working tree to the default branch
+ *   - create the deterministic revert branch
+ *   - `git revert --no-edit <sha>`
+ *   - push + `gh pr create`
+ *
+ * Returns `{ ok: false }` with a one-line error on any failure. The soak
+ * job marks the run as failed but the merge stays on origin — operators
+ * can still revert manually.
+ */
+export async function openRevertPr(args: OpenRevertPrArgs): Promise<OpenRevertPrResult> {
+  const { projPath, repo, defaultBranch, meta, failed, log } = args;
+  const branch = revertBranchName(meta.mergeSha);
+
+  // Make sure we're on the default branch and clean before branching.
+  const statusR = await exec('git', ['-C', projPath, 'status', '--porcelain'], { timeout: 5000 });
+  if (statusR.stdout.trim().length > 0) {
+    log(`# soak revert: working tree dirty, aborting revert PR\n`);
+    return { ok: false, branch, error: 'working tree dirty before revert' };
+  }
+  await exec('git', ['-C', projPath, 'fetch', 'origin', defaultBranch], { timeout: 30_000 });
+  const co = await exec('git', ['-C', projPath, 'checkout', defaultBranch], { timeout: 10_000 });
+  if (co.exitCode !== 0) {
+    log(`# soak revert: checkout ${defaultBranch} failed: ${co.stderr.trim()}\n`);
+    return { ok: false, branch, error: `checkout ${defaultBranch} failed` };
+  }
+  await exec('git', ['-C', projPath, 'pull', '--ff-only', 'origin', defaultBranch], { timeout: 30_000 });
+
+  // Create or reuse the revert branch off the freshly pulled default.
+  const branchR = await exec('git', ['-C', projPath, 'checkout', '-B', branch], { timeout: 10_000 });
+  if (branchR.exitCode !== 0) {
+    log(`# soak revert: branch ${branch} failed: ${branchR.stderr.trim()}\n`);
+    return { ok: false, branch, error: `branch create failed` };
+  }
+
+  const revertR = await exec(
+    'git',
+    ['-C', projPath, 'revert', '--no-edit', meta.mergeSha],
+    { timeout: 30_000 },
+  );
+  if (revertR.exitCode !== 0) {
+    log(`# soak revert: git revert failed: ${revertR.stderr.trim()}\n`);
+    // Bail back to default so the working tree isn't left mid-revert.
+    await exec('git', ['-C', projPath, 'revert', '--abort'], { timeout: 5_000 });
+    await exec('git', ['-C', projPath, 'checkout', defaultBranch], { timeout: 10_000 });
+    return { ok: false, branch, error: 'git revert failed' };
+  }
+
+  const pushR = await exec(
+    'git',
+    ['-C', projPath, 'push', '-u', 'origin', branch, '--force-with-lease'],
+    { timeout: 30_000 },
+  );
+  if (pushR.exitCode !== 0) {
+    log(`# soak revert: push ${branch} failed: ${pushR.stderr.trim()}\n`);
+    return { ok: false, branch, error: 'push failed' };
+  }
+
+  const title = `revert: rollback ${meta.mergeSha.slice(0, 7)} (post-merge CI failure)`;
+  const body = buildRevertPrBody(meta, failed);
+  const prR = await exec(
+    'gh',
+    ['pr', 'create', '--repo', repo, '--base', defaultBranch, '--head', branch, '--title', title, '--body', body],
+    { cwd: projPath, timeout: 30_000 },
+  );
+  if (prR.exitCode !== 0) {
+    // If a PR for this branch already exists, surface its URL instead of failing.
+    const existing = await exec(
+      'gh',
+      ['pr', 'view', branch, '--repo', repo, '--json', 'url', '--jq', '.url'],
+      { cwd: projPath, timeout: 15_000 },
+    );
+    if (existing.exitCode === 0 && existing.stdout.trim().length > 0) {
+      log(`# soak revert: PR already open — ${existing.stdout.trim()}\n`);
+      return { ok: true, prUrl: existing.stdout.trim(), branch };
+    }
+    log(`# soak revert: gh pr create failed: ${prR.stderr.trim()}\n`);
+    return { ok: false, branch, error: 'pr create failed' };
+  }
+  const prUrl = prR.stdout.trim().split(/\s+/).pop() ?? '';
+  return { ok: true, prUrl, branch };
+}
+
+/**
+ * Best-effort: enable squash auto-merge for the just-opened revert PR.
+ * Failure is logged but does not affect the soak job's exit code — the PR
+ * stays open for manual review.
+ */
+export async function autoMergeRevertPr(
+  projPath: string,
+  repo: string,
+  prUrl: string,
+  log: (s: string) => void,
+): Promise<void> {
+  const r = await exec(
+    'gh',
+    ['pr', 'merge', prUrl, '--repo', repo, '--squash', '--auto', '--delete-branch'],
+    { cwd: projPath, timeout: 30_000 },
+  );
+  if (r.stdout) log(r.stdout);
+  if (r.stderr) log(r.stderr);
+  if (r.exitCode !== 0) log(`# soak: auto-merge of revert PR failed (left open for manual review)\n`);
+}
+
+/**
+ * Notify the operator of the revert. Best-effort: `notify` already swallows
+ * webhook errors and never throws.
+ */
+export async function notifyPostMergeRevert(args: {
+  jobId: string;
+  projectName: string;
+  meta: SoakContextMeta;
+  failed: CiRun[];
+  revertPrUrl: string | null;
+  reason: string;
+}): Promise<void> {
+  try {
+    const { notify } = await import('@/lib/shared/notifications');
+    const summary = args.failed
+      .slice(0, 3)
+      .map((f) => f.workflowName ?? 'workflow')
+      .join(', ');
+    await notify({
+      event: 'post_merge_revert',
+      project: args.projectName,
+      job_id: args.jobId,
+      status: 'failed',
+      message: `Default-branch CI failed on ${args.meta.mergeSha.slice(0, 7)} (${summary || 'no workflow name'})`,
+      log_url: args.revertPrUrl ?? args.meta.prUrl,
+      reason: args.reason,
+      timestamp: Date.now(),
+      throttleKeySuffix: args.meta.mergeSha,
+    });
+  } catch (err) {
+    console.error('[soak] notifyPostMergeRevert failed:', err);
+  }
+}
+
+export interface LaunchSoakArgs {
+  projectName: string;
+  meta: SoakContextMeta;
+}
+
+export interface LaunchSoakResult {
+  ok: boolean;
+  jobId?: string;
+  error?: string;
+}
+
+/**
+ * Stand up a soak job row, write the initial log header, and persist the
+ * watcher's context on `contextMeta`. The phase workflow calls this and
+ * then drives the polling loop in its own `'use step'` bodies.
+ */
+export function launchSoak(args: LaunchSoakArgs): LaunchSoakResult {
+  const projPath = resolveProjectPath(args.projectName);
+  if (!projPath) return { ok: false, error: 'project not found' };
+
+  const { logDir } = getImproveConfig();
+  mkdirSync(/*turbopackIgnore: true*/ logDir, { recursive: true });
+
+  const meta = JSON.stringify(args.meta);
+  const job = createJob(args.projectName, 'soak', 0, '', undefined, meta);
+  const logPath = join(/*turbopackIgnore: true*/ logDir, `${job.id}.log`);
+  job.logPath = logPath;
+  updateJob(job);
+
+  try {
+    appendRedactedFileSync(
+      logPath,
+      `# soak start — ${new Date().toISOString()}\n# watching ${args.meta.defaultBranch} CI on ${args.meta.mergeSha} for ${args.meta.watchMinutes} min\n`,
+    );
+  } catch { /* log-write failures are non-fatal */ }
+
+  return { ok: true, jobId: job.id };
+}
+
+/** Append a log line for the soak job, swallowing log-write failures. */
+export function appendSoakLog(jobId: string, line: string): void {
+  const job = getJob(jobId);
+  if (!job?.logPath) return;
+  try { appendRedactedFileSync(job.logPath, line); } catch {}
+}
+
+/** Finalize a soak job row with an exit code. */
+export async function finalizeSoakJob(jobId: string, exitCode: number): Promise<JobData | null> {
+  const job = getJob(jobId);
+  if (!job) return null;
+  await markDone(job, exitCode);
+  return job;
+}

--- a/lib/scheduling/scheduling.ts
+++ b/lib/scheduling/scheduling.ts
@@ -189,6 +189,12 @@ export async function writeProjectFieldYaml(
     run(db.update(schema.projects).set({ website: value }).where(w).execute());
   } else if (fieldName === 'qa_url') {
     run(db.update(schema.projects).set({ qaUrl: value }).where(w).execute());
+  } else if (fieldName === 'post_merge_watch_minutes') {
+    const parsed = value === null ? 0 : Number.parseInt(value, 10);
+    const minutes = Number.isFinite(parsed) && parsed >= 0 ? parsed : 0;
+    run(db.update(schema.projects).set({ postMergeWatchMinutes: minutes }).where(w).execute());
+  } else if (fieldName === 'auto_revert_enabled') {
+    run(db.update(schema.projects).set({ autoRevertEnabled: value === '1' || value === 'true' }).where(w).execute());
   }
   return true;
 }
@@ -246,6 +252,26 @@ export async function getProjectPushResult(projName: string): Promise<{ lastPush
   return { lastPushError: row.lastPushError ?? null, lastPushAt: row.lastPushAt ?? null };
 }
 
+export async function getProjectSoakConfig(projName: string): Promise<{
+  postMergeWatchMinutes: number;
+  autoRevertEnabled: boolean;
+} | null> {
+  const rows = await db
+    .select({
+      postMergeWatchMinutes: schema.projects.postMergeWatchMinutes,
+      autoRevertEnabled: schema.projects.autoRevertEnabled,
+    })
+    .from(schema.projects)
+    .where(eq(schema.projects.name, projName))
+    .limit(1);
+  const row = rows[0] ?? null;
+  if (!row) return null;
+  return {
+    postMergeWatchMinutes: row.postMergeWatchMinutes ?? 0,
+    autoRevertEnabled: !!row.autoRevertEnabled,
+  };
+}
+
 export async function getProjectTestConfig(projName: string): Promise<{
   testCommand: string | null;
   testCronEnabled: boolean;
@@ -257,6 +283,8 @@ export async function getProjectTestConfig(projName: string): Promise<{
   issueAutoBranch: boolean;
   testsDisabled: boolean;
   reviewDisabled: boolean;
+  postMergeWatchMinutes: number;
+  autoRevertEnabled: boolean;
 } | null> {
   const rows = await db
     .select()
@@ -276,6 +304,8 @@ export async function getProjectTestConfig(projName: string): Promise<{
     issueAutoBranch: row.issueAutoBranch ?? true,
     testsDisabled: !!row.testsDisabled,
     reviewDisabled: !!row.reviewDisabled,
+    postMergeWatchMinutes: row.postMergeWatchMinutes ?? 0,
+    autoRevertEnabled: !!row.autoRevertEnabled,
   };
 }
 

--- a/lib/shared/config.ts
+++ b/lib/shared/config.ts
@@ -88,6 +88,7 @@ export interface TamTamConfig {
   notification_on_fix_loop_exhausted: boolean;
   notification_on_review_do_not_ship: boolean;
   notification_on_agent_run_fail: boolean;
+  notification_on_post_merge_revert: boolean;
   notification_throttle_window_seconds: number;
   notification_throttle_overrides: Record<string, number>;
   pipeline_model_review: string;
@@ -186,6 +187,7 @@ const DEFAULTS: TamTamConfig = {
   notification_on_fix_loop_exhausted: false,
   notification_on_review_do_not_ship: false,
   notification_on_agent_run_fail: false,
+  notification_on_post_merge_revert: false,
   notification_throttle_window_seconds: 900,
   notification_throttle_overrides: { release_fail: 0, release_aborted: 0 },
   // Empty string = use the per-step sensible default (review/fix → workspace
@@ -401,6 +403,7 @@ export function buildConfigFromSettingsMap(map: Record<string, string>): TamTamC
     notification_on_fix_loop_exhausted: map.notification_on_fix_loop_exhausted === 'true',
     notification_on_review_do_not_ship: map.notification_on_review_do_not_ship === 'true',
     notification_on_agent_run_fail: map.notification_on_agent_run_fail === 'true',
+    notification_on_post_merge_revert: map.notification_on_post_merge_revert === 'true',
     notification_throttle_window_seconds: parseIntOr(
       map.notification_throttle_window_seconds,
       DEFAULTS.notification_throttle_window_seconds

--- a/lib/shared/notifications.ts
+++ b/lib/shared/notifications.ts
@@ -10,7 +10,8 @@ export type NotificationEvent =
   | 'fix_loop_exhausted'
   | 'review_do_not_ship'
   | 'agent_run_fail'
-  | 'budget_blocked';
+  | 'budget_blocked'
+  | 'post_merge_revert';
 
 export interface NotificationPayload {
   event: NotificationEvent;
@@ -65,6 +66,9 @@ function getNotificationConfig(event: NotificationEvent): NotificationConfig {
     case 'budget_blocked':
       enabled = settings.notification_on_budget_blocked || false;
       break;
+    case 'post_merge_revert':
+      enabled = settings.notification_on_post_merge_revert || false;
+      break;
   }
 
   return { webhook_url: webhookUrl, webhook_secret: webhookSecret, enabled };
@@ -87,6 +91,7 @@ function throttleSubject(payload: NotificationPayload): string {
     case 'review_do_not_ship': return 'review';
     case 'fix_loop_exhausted': return 'fix';
     case 'budget_blocked': return 'budget';
+    case 'post_merge_revert': return 'soak';
     default: return 'release';
   }
 }

--- a/lib/workflows/decide-next-phase.ts
+++ b/lib/workflows/decide-next-phase.ts
@@ -34,7 +34,8 @@ export type NextPhase =
   | { next: 'abort'; from: 'review'; verdict: 'DO NOT SHIP' | 'NEEDS ATTENTION'; stopReason?: string }
   | { next: 'mark-dod'; from: 'push' }
   | { next: 'pr-wait'; from: 'mark-dod' | 'push'; pr: { prNumber: number; prRepo: string; prUrl: string } }
-  | { next: 'done'; from: 'mark-dod' | 'pr-wait' | 'commit' | 'fix' | 'push' }
+  | { next: 'soak'; from: 'pr-wait'; soak: { mergeSha: string; prNumber: number; prRepo: string; prUrl: string; defaultBranch: string; watchMinutes: number; autoRevert: boolean } }
+  | { next: 'done'; from: 'mark-dod' | 'pr-wait' | 'soak' | 'commit' | 'fix' | 'push' }
   | { next: 'unknown'; from: string; reason: string };
 
 export interface DecisionInputs {
@@ -63,6 +64,10 @@ export interface DecisionInputs {
   hasUncommittedChanges?: boolean;
   /** Whether the current branch has local commits not pushed upstream. */
   hasUnpushedCommits?: boolean;
+  /** Soak context. Provided after a successful pr-wait when the project
+   *  has a positive `post_merge_watch_minutes`. When set, pr-wait routes
+   *  to the new `soak` phase before the chain terminates. */
+  soakContext?: { mergeSha: string; prNumber: number; prRepo: string; prUrl: string; defaultBranch: string; watchMinutes: number; autoRevert: boolean } | null;
 }
 
 import { TRANSITIONS, matchesPattern, buildNextPhase } from './pipeline-spec';

--- a/lib/workflows/dispatch-phase.ts
+++ b/lib/workflows/dispatch-phase.ts
@@ -28,6 +28,9 @@ export interface DispatchContext {
   prevJobId?: string;
   /** PR identity. pr-wait needs all three. */
   pr?: { prNumber: number; prRepo: string; prUrl: string };
+  /** Soak context. Only the soak phase consumes this; resolved from the
+   *  release's pr-wait + project soak settings just before dispatch. */
+  soak?: { mergeSha: string; prNumber: number; prRepo: string; prUrl: string; defaultBranch: string; watchMinutes: number; autoRevert: boolean };
   /** Targeting override for mark-dod (issueNumber / prNumber / repo). */
   dodOverride?: MarkDodOverride;
   /** Forwarded to push/commit phases for chain tracking. */
@@ -143,6 +146,15 @@ export async function dispatchPhase(
         ]);
         break;
       }
+      case 'soak': {
+        const { releaseSoakPhaseWorkflow } = await import('@/lib/workflows/phases/soak-phase');
+        run = await start(releaseSoakPhaseWorkflow, [
+          ctx.projectName,
+          ctx.soak!,
+          ctx.parentJobId,
+        ]);
+        break;
+      }
     }
       if (!run) {
         // Type-narrowing should make this unreachable, but be defensive.
@@ -226,6 +238,7 @@ function jobKindForNextPhase(phase: NextPhase['next']): string | null {
     case 'push': return 'push';
     case 'mark-dod': return 'mark-dod';
     case 'pr-wait': return 'pr-wait';
+    case 'soak': return 'soak';
     default: return null;
   }
 }
@@ -258,6 +271,14 @@ function requiredContextMissing(phase: NextPhase['next'], ctx: DispatchContext):
     if (!ctx.pr?.prNumber) missing.push('pr.prNumber');
     if (!ctx.pr?.prRepo) missing.push('pr.prRepo');
     if (!ctx.pr?.prUrl) missing.push('pr.prUrl');
+  }
+  if (phase === 'soak') {
+    if (!ctx.soak?.prNumber) missing.push('soak.prNumber');
+    if (!ctx.soak?.prRepo) missing.push('soak.prRepo');
+    if (!ctx.soak?.prUrl) missing.push('soak.prUrl');
+    if (!ctx.soak?.mergeSha) missing.push('soak.mergeSha');
+    if (!ctx.soak?.defaultBranch) missing.push('soak.defaultBranch');
+    if (!ctx.soak?.watchMinutes || ctx.soak.watchMinutes <= 0) missing.push('soak.watchMinutes');
   }
   // test, review, commit, push, mark-dod only need projectName.
   return missing;

--- a/lib/workflows/phases/soak-phase.ts
+++ b/lib/workflows/phases/soak-phase.ts
@@ -1,0 +1,321 @@
+// Soak phase workflow. Runs after `pr-wait` merges a release PR. Watches
+// the default branch's CI on the merge commit for a configurable window and
+// — on failure — opens (and optionally auto-merges) a revert PR.
+//
+// The phase is no-op when the project's `post_merge_watch_minutes` is 0 or
+// the prior pr-wait did not actually merge. In both cases the workflow
+// returns `{ ok: true, skipped: true }` and the orchestrator finalises the
+// release normally.
+//
+// Each side-effectful operation (gh poll, revert PR, finalize) lives in a
+// `'use step'` body so its result is cached and replay-safe.
+
+import { sleep } from 'workflow';
+import { safeStartOrchestrator } from '@/lib/workflows/safe-start-orchestrator';
+import type { CiRun, SoakContextMeta } from '@/lib/pipeline/start-soak';
+
+export type SoakPhaseResult =
+  | {
+      ok: true;
+      skipped: true;
+      reason: 'disabled' | 'no_merge_sha';
+    }
+  | {
+      ok: true;
+      jobId: string;
+      verdict: 'pass' | 'fail' | 'timeout';
+      revertPrUrl: string | null;
+      autoMerged: boolean;
+    }
+  | {
+      ok: false;
+      reason: 'launch_failed';
+      error: string;
+    };
+
+interface SoakPrepInput {
+  /** Resolved by the orchestrator from gh + project config — passed through
+   *  so the soak phase does not duplicate the gh round-trips. */
+  mergeSha: string;
+  defaultBranch: string;
+  watchMinutes: number;
+  autoRevert: boolean;
+  prNumber: number;
+  prRepo: string;
+  prUrl: string;
+}
+
+interface SoakPrepResult {
+  ok: boolean;
+  skipped?: true;
+  reason?: 'disabled' | 'no_merge_sha' | 'launch_failed';
+  error?: string;
+  jobId?: string;
+  projPath?: string;
+  meta?: SoakContextMeta;
+  deadlineAt?: number;
+}
+
+export async function releaseSoakPhaseWorkflow(
+  projectName: string,
+  prep: SoakPrepInput,
+  releaseJobId?: string,
+): Promise<SoakPhaseResult> {
+  'use workflow';
+
+  const prepared = await prepareSoakStep({ ...prep, projectName, releaseJobId });
+  if (!prepared.ok) {
+    if (prepared.skipped) {
+      // Skip path: pretend the soak phase finalised cleanly and let the
+      // orchestrator close the release via the dispatched tick.
+      if (releaseJobId) {
+        await finalizeReleaseDirectlyStep(releaseJobId, 0);
+      }
+      const reason = prepared.reason === 'no_merge_sha' ? 'no_merge_sha' : 'disabled';
+      return { ok: true, skipped: true, reason };
+    }
+    return { ok: false, reason: 'launch_failed', error: prepared.error ?? 'unknown' };
+  }
+
+  const { jobId, meta, projPath, deadlineAt } = prepared;
+  if (!jobId || !meta || !projPath || !deadlineAt) {
+    return { ok: false, reason: 'launch_failed', error: 'missing prep fields' };
+  }
+
+  let verdict: 'pass' | 'fail' | 'timeout' = 'timeout';
+  let failedRuns: CiRun[] = [];
+
+  while (true) {
+    const poll = await pollDefaultBranchCiStep(jobId, projPath, meta, deadlineAt);
+    if (poll.expired) { verdict = 'timeout'; break; }
+    if (poll.classification === 'fail') {
+      verdict = 'fail';
+      failedRuns = poll.failed;
+      break;
+    }
+    if (poll.classification === 'pass') {
+      verdict = 'pass';
+      break;
+    }
+    // `pending` / `none` — keep polling until the deadline.
+    await sleep(poll.intervalMs);
+  }
+
+  let revertPrUrl: string | null = null;
+  let autoMerged = false;
+  if (verdict === 'fail') {
+    const revert = await openRevertPrStep(jobId, projPath, meta, failedRuns);
+    revertPrUrl = revert.prUrl ?? null;
+    if (revert.ok && revert.prUrl && meta.autoRevert) {
+      autoMerged = await autoMergeRevertStep(jobId, projPath, meta.prRepo, revert.prUrl);
+    }
+    await notifyRevertStep(jobId, projectName, meta, failedRuns, revertPrUrl);
+  }
+
+  const exitCode = verdict === 'fail' ? 1 : 0;
+  await finalizeSoakStep(jobId, exitCode, verdict);
+
+  // soak is a terminal phase — re-dispatch the orchestrator so it sees
+  // decideNextPhase=done and finalises the release meta-job.
+  if (releaseJobId) {
+    await dispatchOrchestratorTickStep(jobId, projectName, releaseJobId);
+  }
+
+  return { ok: true, jobId, verdict, revertPrUrl, autoMerged };
+}
+
+// ── Steps ────────────────────────────────────────────────────────────────────
+
+interface PrepareSoakStepInput extends SoakPrepInput {
+  projectName: string;
+  releaseJobId?: string;
+}
+
+async function prepareSoakStep(input: PrepareSoakStepInput): Promise<SoakPrepResult> {
+  'use step';
+  const { resolveProjectPath } = await import('@/lib/shared/project-data');
+  const { launchSoak } = await import('@/lib/pipeline/start-soak');
+
+  const projPath = resolveProjectPath(input.projectName);
+  if (!projPath) return { ok: false, error: 'project not found', reason: 'launch_failed' };
+
+  if (!input.watchMinutes || input.watchMinutes <= 0) {
+    return { ok: false, skipped: true, reason: 'disabled' };
+  }
+  if (!input.mergeSha) {
+    return { ok: false, skipped: true, reason: 'no_merge_sha' };
+  }
+
+  const meta: SoakContextMeta = {
+    mergeSha: input.mergeSha,
+    prRepo: input.prRepo,
+    prNumber: input.prNumber,
+    prUrl: input.prUrl,
+    defaultBranch: input.defaultBranch,
+    watchMinutes: input.watchMinutes,
+    autoRevert: input.autoRevert,
+  };
+
+  // Wrap createJob in runWithParent so the soak row inherits release_id.
+  let launched;
+  if (input.releaseJobId) {
+    const { runWithParent } = await import('@/lib/jobs/parent-context');
+    launched = await runWithParent(input.releaseJobId, () =>
+      launchSoak({ projectName: input.projectName, meta }),
+    );
+  } else {
+    launched = launchSoak({ projectName: input.projectName, meta });
+  }
+  if (!launched.ok || !launched.jobId) {
+    return { ok: false, error: launched.error ?? 'launch failed', reason: 'launch_failed' };
+  }
+
+  return {
+    ok: true,
+    jobId: launched.jobId,
+    projPath,
+    meta,
+    deadlineAt: Date.now() + meta.watchMinutes * 60_000,
+  };
+}
+
+interface PollDefaultBranchResult {
+  expired: boolean;
+  classification: 'pass' | 'fail' | 'pending' | 'none';
+  failed: CiRun[];
+  intervalMs: number;
+}
+
+async function pollDefaultBranchCiStep(
+  jobId: string,
+  projPath: string,
+  meta: SoakContextMeta,
+  deadlineAt: number,
+): Promise<PollDefaultBranchResult> {
+  'use step';
+  const {
+    appendSoakLog,
+    classifyDefaultBranchCi,
+    queryDefaultBranchCi,
+    SOAK_DEFAULT_POLL_INTERVAL_MS,
+  } = await import('@/lib/pipeline/start-soak');
+  const intervalMs = SOAK_DEFAULT_POLL_INTERVAL_MS;
+
+  if (Date.now() >= deadlineAt) {
+    appendSoakLog(jobId, `\n# soak window elapsed — no failures observed\n`);
+    return { expired: true, classification: 'none', failed: [], intervalMs };
+  }
+  const runs = await queryDefaultBranchCi({
+    projPath,
+    repo: meta.prRepo,
+    defaultBranch: meta.defaultBranch,
+    mergeSha: meta.mergeSha,
+  });
+  const verdict = classifyDefaultBranchCi(runs);
+  appendSoakLog(
+    jobId,
+    `\n# soak poll: ${runs.length} run(s), verdict=${verdict.kind}\n`,
+  );
+  if (verdict.kind === 'fail') {
+    return { expired: false, classification: 'fail', failed: verdict.failed, intervalMs };
+  }
+  if (verdict.kind === 'pass') {
+    return { expired: false, classification: 'pass', failed: [], intervalMs };
+  }
+  return { expired: false, classification: verdict.kind === 'pending' ? 'pending' : 'none', failed: [], intervalMs };
+}
+
+async function openRevertPrStep(
+  jobId: string,
+  projPath: string,
+  meta: SoakContextMeta,
+  failed: CiRun[],
+): Promise<{ ok: boolean; prUrl?: string }> {
+  'use step';
+  const { openRevertPr, appendSoakLog } = await import('@/lib/pipeline/start-soak');
+  appendSoakLog(jobId, `\n# soak: opening revert PR for ${meta.mergeSha}\n`);
+  const r = await openRevertPr({
+    projPath,
+    repo: meta.prRepo,
+    defaultBranch: meta.defaultBranch,
+    meta,
+    failed,
+    log: (s) => appendSoakLog(jobId, s),
+  });
+  if (r.ok && r.prUrl) appendSoakLog(jobId, `\n# soak: revert PR opened ${r.prUrl}\n`);
+  return { ok: r.ok, prUrl: r.prUrl };
+}
+
+async function autoMergeRevertStep(
+  jobId: string,
+  projPath: string,
+  repo: string,
+  prUrl: string,
+): Promise<boolean> {
+  'use step';
+  const { autoMergeRevertPr, appendSoakLog } = await import('@/lib/pipeline/start-soak');
+  appendSoakLog(jobId, `\n# soak: enabling auto-merge for revert PR\n`);
+  try {
+    await autoMergeRevertPr(projPath, repo, prUrl, (s) => appendSoakLog(jobId, s));
+    return true;
+  } catch (err) {
+    appendSoakLog(jobId, `\n# soak: auto-merge errored: ${err instanceof Error ? err.message : String(err)}\n`);
+    return false;
+  }
+}
+
+async function notifyRevertStep(
+  jobId: string,
+  projectName: string,
+  meta: SoakContextMeta,
+  failed: CiRun[],
+  revertPrUrl: string | null,
+): Promise<void> {
+  'use step';
+  const { notifyPostMergeRevert } = await import('@/lib/pipeline/start-soak');
+  await notifyPostMergeRevert({
+    jobId,
+    projectName,
+    meta,
+    failed,
+    revertPrUrl,
+    reason: 'default_branch_ci_failed',
+  });
+}
+
+async function finalizeSoakStep(
+  jobId: string,
+  exitCode: number,
+  verdict: string,
+): Promise<void> {
+  'use step';
+  const { appendSoakLog, finalizeSoakJob } = await import('@/lib/pipeline/start-soak');
+  appendSoakLog(jobId, `\n# soak finished — verdict ${verdict} (exit ${exitCode})\n`);
+  await finalizeSoakJob(jobId, exitCode);
+}
+
+async function dispatchOrchestratorTickStep(
+  jobId: string,
+  projectName: string,
+  releaseJobId: string,
+): Promise<void> {
+  'use step';
+  await safeStartOrchestrator(jobId, projectName, releaseJobId, 'soak-phase');
+}
+
+async function finalizeReleaseDirectlyStep(
+  releaseJobId: string,
+  exitCode: number,
+): Promise<void> {
+  'use step';
+  try {
+    const { getJob } = await import('@/lib/jobs/job-storage');
+    const { finalizeReleaseJob } = await import('@/lib/jobs/lifecycle');
+    const release = getJob(releaseJobId);
+    if (release && release.kind === 'release' && release.finishedAt == null) {
+      await finalizeReleaseJob(release, exitCode);
+    }
+  } catch (err) {
+    console.error('[soak-phase] failed to finalize release directly:', err);
+  }
+}

--- a/lib/workflows/pipeline-spec.ts
+++ b/lib/workflows/pipeline-spec.ts
@@ -26,7 +26,7 @@ export const TRIGGERS = [
 // ─── Phase names ───────────────────────────────────────────────────────────
 
 export type PhaseName =
-  | 'test' | 'review' | 'fix' | 'commit' | 'push' | 'mark-dod' | 'pr-wait';
+  | 'test' | 'review' | 'fix' | 'commit' | 'push' | 'mark-dod' | 'pr-wait' | 'soak';
 export type TerminalName = 'done' | 'abort' | 'unknown';
 export type ExternalPhaseName = 'fix-ci';
 export type TransitionTarget = PhaseName | TerminalName | ExternalPhaseName;
@@ -45,6 +45,9 @@ export type WhenClause = {
   /** Presence check on optional input fields. Truthy = field is set and
    *  truthy; falsy = field is unset or falsy. */
   hasPushPrContext?: boolean;
+  /** Presence check on the soak context — true means a positive
+   *  `post_merge_watch_minutes` was resolved before this transition. */
+  hasSoakContext?: boolean;
   /** Sentinel marking transitions fired OUTSIDE decideNextPhase — included
    *  for diagram completeness only. Spec-driven matcher ignores them. */
   external?: 'checks_failed' | 'exit 0';
@@ -63,7 +66,7 @@ export interface Transition {
   label: string;
   /** Metadata field names the dispatcher must propagate from inputs to the
    *  NextPhase output (e.g. 'testExitCode', 'pushPrContext'). */
-  carries?: ReadonlyArray<'testExitCode' | 'verdict' | 'pushPrContext' | 'stopReason'>;
+  carries?: ReadonlyArray<'testExitCode' | 'verdict' | 'pushPrContext' | 'stopReason' | 'soakContext'>;
   /** Constant projection fields the matcher should set on the NextPhase. */
   set?: Record<string, string>;
   /** Guards that may rewrite this decision before dispatch. Diagram annotates
@@ -130,15 +133,21 @@ export const TRANSITIONS: ReadonlyArray<Transition> = [
   { from: 'mark-dod', when: {},
     to: 'done',    label: 'otherwise' },
 
-  // pr-wait → done is the normal path. checks_failed → fix-ci is dispatched
+  // pr-wait → soak when the project opted in to a post-merge watch window;
+  // otherwise pr-wait → done as before. checks_failed → fix-ci is dispatched
   // by the pr-wait phase itself, not by decideNextPhase; declared here so
   // the diagram shows the loop.
+  { from: 'pr-wait', when: { exitCode: 0, hasSoakContext: true },
+    to: 'soak', label: 'soak enabled', carries: ['soakContext'] },
   { from: 'pr-wait', when: {},
     to: 'done', label: 'merged' },
   { from: 'pr-wait', when: { external: 'checks_failed' },
     to: 'fix-ci', label: 'checks_failed', external: true },
   { from: 'fix-ci' as PhaseName, when: { external: 'exit 0' },
     to: 'test', label: 'exit 0', external: true },
+
+  // soak terminates the chain — outcome is reflected by its own exit code.
+  { from: 'soak', when: {}, to: 'done', label: 'soak complete' },
 ];
 
 // ─── Matcher ───────────────────────────────────────────────────────────────
@@ -167,6 +176,12 @@ export function matchesPattern(inputs: DecisionInputs, when: WhenClause): boolea
       if (expected === false && present) return false;
       continue;
     }
+    if (key === 'hasSoakContext') {
+      const present = inputs.soakContext != null;
+      if (expected === true && !present) return false;
+      if (expected === false && present) return false;
+      continue;
+    }
     const actual = (inputs as unknown as Record<string, unknown>)[key];
     if (!matchValue(actual, expected)) return false;
   }
@@ -190,6 +205,8 @@ export function buildNextPhase(
     for (const field of t.carries) {
       if (field === 'pushPrContext') {
         if (inputs.pushPrContext) base.pr = inputs.pushPrContext;
+      } else if (field === 'soakContext') {
+        if (inputs.soakContext) base.soak = inputs.soakContext;
       } else if (field === 'testExitCode') {
         base.testExitCode = inputs.exitCode;
       } else if (field === 'verdict') {

--- a/lib/workflows/release-orchestrator.ts
+++ b/lib/workflows/release-orchestrator.ts
@@ -49,6 +49,9 @@ export async function releaseOrchestratorWorkflow(
   if (decision.next === 'pr-wait') {
     dispatchCtx.pr = decision.pr;
   }
+  if (decision.next === 'soak') {
+    dispatchCtx.soak = decision.soak;
+  }
   const dispatch = await dispatchStep(decision, dispatchCtx);
   // Finalize the release meta-job whenever this tick did not start a child
   // workflow — otherwise the release sits in `running` until the wall-clock
@@ -238,6 +241,59 @@ async function decideStep(jobId: string): Promise<NextPhase> {
       } catch {}
     }
   }
+  // After a successful pr-wait merge, decide whether to enter the soak
+  // watch window. Soak is opt-in per project — disabled (0 minutes) means
+  // the release ends here just as it did before. We resolve everything the
+  // soak phase needs (merge sha + PR identity + default branch) here so
+  // the decideNextPhase function stays pure data-in / data-out.
+  let soakContext: { mergeSha: string; prNumber: number; prRepo: string; prUrl: string; defaultBranch: string; watchMinutes: number; autoRevert: boolean } | null = null;
+  if (job.kind === 'pr-wait' && job.releaseId && (job.exitCode ?? -1) === 0) {
+    try {
+      const { getProjectSoakConfig } = await import('@/lib/scheduling/scheduling');
+      const soakCfg = await getProjectSoakConfig(job.project);
+      if (soakCfg && soakCfg.postMergeWatchMinutes > 0) {
+        const prMeta = job.contextMeta ? JSON.parse(job.contextMeta) as { prNumber?: number; prRepo?: string; prUrl?: string } : {};
+        if (prMeta.prNumber && prMeta.prRepo && prMeta.prUrl) {
+          const { resolveProjectPath } = await import('@/lib/shared/project-data');
+          const projPath = resolveProjectPath(job.project);
+          if (projPath) {
+            const { detectMainBranch } = await import('@/lib/pipeline/start-commit');
+            const defaultBranch = await detectMainBranch(projPath);
+            // Prefer the PR's recorded merge commit (canonical for squash
+            // and rebase merges) and fall back to the local default-branch
+            // tip if gh is unavailable. Without the fallback we'd silently
+            // skip soak in offline environments.
+            const { exec } = await import('@/lib/shared/shell');
+            let mergeSha = '';
+            const ghMerge = await exec(
+              'gh',
+              ['pr', 'view', String(prMeta.prNumber), '--repo', prMeta.prRepo, '--json', 'mergeCommit', '--jq', '.mergeCommit.oid'],
+              { cwd: projPath, timeout: 15_000 },
+            );
+            if (ghMerge.exitCode === 0) mergeSha = ghMerge.stdout.trim();
+            if (!mergeSha) {
+              await exec('git', ['-C', projPath, 'fetch', 'origin', defaultBranch], { timeout: 30_000 });
+              const shaR = await exec('git', ['-C', projPath, 'rev-parse', `origin/${defaultBranch}`], { timeout: 10_000 });
+              if (shaR.exitCode === 0) mergeSha = shaR.stdout.trim();
+            }
+            if (mergeSha) {
+              soakContext = {
+                mergeSha,
+                prNumber: prMeta.prNumber,
+                prRepo: prMeta.prRepo,
+                prUrl: prMeta.prUrl,
+                defaultBranch,
+                watchMinutes: soakCfg.postMergeWatchMinutes,
+                autoRevert: soakCfg.autoRevertEnabled,
+              };
+            }
+          }
+        }
+      }
+    } catch (err) {
+      console.warn('[release-orchestrator] soak context resolution failed:', err);
+    }
+  }
   const decision = decideNextPhase({
     kind: job.kind,
     exitCode: job.exitCode ?? -1,
@@ -248,6 +304,7 @@ async function decideStep(jobId: string): Promise<NextPhase> {
     reviewDisabled,
     hasUncommittedChanges,
     hasUnpushedCommits,
+    soakContext,
   });
   // Pre-dispatch guards: convert `{ next: 'fix' }` into `{ next: 'abort' }`
   // when the fix loop would not converge (reviewIsStuck/fixContradictsReview),

--- a/scripts/gen-workflow-graph.mjs
+++ b/scripts/gen-workflow-graph.mjs
@@ -80,7 +80,7 @@ function buildMermaid({ TRIGGERS, TRANSITIONS }) {
     if (!byFrom.has(t.from)) byFrom.set(t.from, []);
     byFrom.get(t.from).push(t);
   }
-  const phaseOrder = ['test', 'review', 'fix', 'commit', 'push', 'mark-dod', 'pr-wait', 'fix-ci'];
+  const phaseOrder = ['test', 'review', 'fix', 'commit', 'push', 'mark-dod', 'pr-wait', 'soak', 'fix-ci'];
   for (const from of phaseOrder) {
     const rows = byFrom.get(from);
     if (!rows) continue;


### PR DESCRIPTION
Closes #26

Implemented post-merge soak watcher (#26) — new `soak` phase polls default-branch CI on the merge commit, opens a revert PR on failure (auto-merging when `auto_revert_enabled` is set), and fires the new `post_merge_revert` notification event.

---
Implemented via TamTam from issue [#26](https://github.com/3h4x/tamtam/issues/26).