### PR TITLE
fix: Estimate prompt cost before spawning runs so oversized sessions fail early

### DIFF
--- a/__tests__/api/issue-branch.test.ts
+++ b/__tests__/api/issue-branch.test.ts
@@ -120,6 +120,9 @@ describe('POST /api/projects/by-project/[projectName]/issue-branch', () => {
       .mockResolvedValueOnce(makeExecResult({ stdout: 'master\n' }))                       // branch --show-current
       .mockResolvedValueOnce(makeExecResult({ stdout: 'refs/remotes/origin/master\n' }))   // symbolic-ref
       .mockResolvedValueOnce(makeExecResult({ stdout: '  master\n  other\n' }))            // branch --merged (no match)
+      .mockResolvedValueOnce(makeExecResult())                                             // fetch origin/default
+      .mockResolvedValueOnce(makeExecResult({ stdout: 'abc123\n' }))                       // rev-parse origin/default
+      .mockResolvedValueOnce(makeExecResult({ exitCode: 128, stderr: 'cannot carry changes' })) // checkout -b from origin
       .mockResolvedValueOnce(makeExecResult({ exitCode: 128, stderr: 'branch already exists' })) // checkout -b
       .mockResolvedValueOnce(makeExecResult({ exitCode: 0 }));                             // checkout
     const res = await POST(makeRequest({ issue_number: 3, issue_title: 'fix bug' }), {
@@ -136,6 +139,9 @@ describe('POST /api/projects/by-project/[projectName]/issue-branch', () => {
       .mockResolvedValueOnce(makeExecResult({ stdout: 'master\n' }))
       .mockResolvedValueOnce(makeExecResult({ stdout: 'refs/remotes/origin/master\n' }))
       .mockResolvedValueOnce(makeExecResult({ stdout: '  master\n' }))
+      .mockResolvedValueOnce(makeExecResult())
+      .mockResolvedValueOnce(makeExecResult({ stdout: 'abc123\n' }))
+      .mockResolvedValueOnce(makeExecResult({ exitCode: 128, stderr: 'cannot carry changes' }))
       .mockResolvedValueOnce(makeExecResult({ exitCode: 128, stderr: 'branch exists' }))
       .mockResolvedValueOnce(makeExecResult({ exitCode: 1, stderr: 'error' }));
     const res = await POST(makeRequest({ issue_number: 5 }), {

--- a/__tests__/lib/issue-branch.test.ts
+++ b/__tests__/lib/issue-branch.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mocks = vi.hoisted(() => ({ exec: vi.fn() }));
+vi.mock('@/lib/shared/shell', () => ({ exec: mocks.exec }));
+vi.mock('@/lib/scheduling/scheduling', () => ({
+  getProjectTestConfig: vi.fn(async () => ({ issueAutoBranch: true })),
+}));
+vi.mock('@/lib/pipeline/pipeline-lock', () => ({ getLock: vi.fn(async () => null) }));
+vi.mock('@/lib/jobs/job-storage', () => ({ listJobs: vi.fn(() => []) }));
+vi.mock('@/lib/shared/project-data', () => ({ clearProjectDataCache: vi.fn() }));
+
+import { ensureIssueBranch, issueBranchName } from '@/lib/github/issue-branch';
+
+function resp(stdout = '', exitCode = 0) {
+  return { stdout, stderr: exitCode === 0 ? '' : 'err', exitCode };
+}
+
+beforeEach(() => mocks.exec.mockReset());
+
+describe('ensureIssueBranch — cuts the issue branch from fresh origin/<default>', () => {
+  it('fetches origin and creates the branch from origin/<default> (not stale local HEAD)', async () => {
+    mocks.exec.mockImplementation(async (...call: unknown[]) => {
+      const a = (Array.isArray(call[1]) ? (call[1] as string[]) : []).join(" ");
+      if (a.includes('branch --show-current')) return resp('master');
+      if (a.includes('symbolic-ref')) return resp('origin/master');
+      if (a.includes('branch --merged')) return resp('');
+      if (a.includes('fetch')) return resp('');
+      if (a.includes('rev-parse --verify')) return resp('abc');
+      if (a.includes('checkout -b')) return resp('Switched');
+      return resp('');
+    });
+    const r = await ensureIssueBranch({ projectName: 'p', projPath: '/p', issueNumber: 90, issueTitle: 'Do a thing' });
+    expect(r.status).toBe('created');
+    const calls = mocks.exec.mock.calls.map((c) => (c[1] as string[]).join(' '));
+    expect(calls.some((c) => c.includes('fetch --quiet origin master'))).toBe(true);
+    expect(calls.find((c) => c.includes('checkout -b'))).toContain('origin/master');
+  });
+
+  it('falls back to a plain create from local HEAD when the origin-based checkout fails', async () => {
+    let checkoutAttempts = 0;
+    mocks.exec.mockImplementation(async (...call: unknown[]) => {
+      const a = (Array.isArray(call[1]) ? (call[1] as string[]) : []).join(" ");
+      if (a.includes('branch --show-current')) return resp('master');
+      if (a.includes('symbolic-ref')) return resp('origin/master');
+      if (a.includes('branch --merged')) return resp('');
+      if (a.includes('fetch')) return resp('');
+      if (a.includes('rev-parse --verify')) return resp('abc');
+      if (a.includes('checkout -b')) {
+        checkoutAttempts++;
+        return a.includes('origin/master') ? resp('', 1) : resp('Switched');
+      }
+      return resp('');
+    });
+    const r = await ensureIssueBranch({ projectName: 'p', projPath: '/p', issueNumber: 90, issueTitle: 't' });
+    expect(r.status).toBe('created');
+    expect(checkoutAttempts).toBe(2); // origin attempt failed → fell back to local HEAD
+  });
+
+  it('reuses an existing branch when both create attempts fail but checkout succeeds', async () => {
+    mocks.exec.mockImplementation(async (...call: unknown[]) => {
+      const a = (Array.isArray(call[1]) ? (call[1] as string[]) : []).join(" ");
+      if (a.includes('branch --show-current')) return resp('master');
+      if (a.includes('symbolic-ref')) return resp('origin/master');
+      if (a.includes('branch --merged')) return resp('');
+      if (a.includes('fetch')) return resp('');
+      if (a.includes('rev-parse --verify')) return resp('abc');
+      if (a.includes('checkout -b')) return resp('', 1);
+      if (a.includes('checkout fix/issue-90-t')) return resp('Switched');
+      return resp('');
+    });
+    const r = await ensureIssueBranch({ projectName: 'p', projPath: '/p', issueNumber: 90, issueTitle: 't' });
+    expect(r).toEqual({ status: 'reused', branch: 'fix/issue-90-t' });
+  });
+
+  it('returns an error when create and reuse checkouts all fail', async () => {
+    mocks.exec.mockImplementation(async (...call: unknown[]) => {
+      const a = (Array.isArray(call[1]) ? (call[1] as string[]) : []).join(" ");
+      if (a.includes('branch --show-current')) return resp('master');
+      if (a.includes('symbolic-ref')) return resp('origin/master');
+      if (a.includes('branch --merged')) return resp('');
+      if (a.includes('fetch')) return resp('');
+      if (a.includes('rev-parse --verify')) return resp('abc');
+      if (a.includes('checkout')) return resp('', 1);
+      return resp('');
+    });
+    const r = await ensureIssueBranch({ projectName: 'p', projPath: '/p', issueNumber: 90, issueTitle: 't' });
+    expect(r.status).toBe('error');
+    if (r.status !== 'error') throw new Error(`expected error, got ${r.status}`);
+    expect(r.detail).toContain('Failed to checkout fix/issue-90-t');
+  });
+
+  it('is idempotent: already-on-branch when current branch is the issue branch', async () => {
+    const branch = issueBranchName(90, 'Do a thing');
+    mocks.exec.mockImplementation(async (...call: unknown[]) => {
+      const a = (Array.isArray(call[1]) ? (call[1] as string[]) : []).join(" ");
+      if (a.includes('branch --show-current')) return resp(branch);
+      if (a.includes('symbolic-ref')) return resp('origin/master');
+      return resp('');
+    });
+    const r = await ensureIssueBranch({ projectName: 'p', projPath: '/p', issueNumber: 90, issueTitle: 'Do a thing' });
+    expect(r.status).toBe('already-on-branch');
+  });
+
+  it('skips when issue_auto_branch is disabled for the project', async () => {
+    const { getProjectTestConfig } = await import('@/lib/scheduling/scheduling');
+    (getProjectTestConfig as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ issueAutoBranch: false });
+    const r = await ensureIssueBranch({ projectName: 'p', projPath: '/p', issueNumber: 90, issueTitle: 't' });
+    expect(r.status).toBe('skipped');
+  });
+});

--- a/app/api/projects/by-project/[projectName]/run/route.ts
+++ b/app/api/projects/by-project/[projectName]/run/route.ts
@@ -285,6 +285,31 @@ export async function POST(
     }, { status: 413 });
   }
 
+  // Issue runs work on their OWN branch from the start, not the default branch.
+  // Check out fix/issue-<n> (cut fresh from origin/<default>) BEFORE creating the
+  // job / spawning the agent, so its in-progress changes never sit exposed on the
+  // default branch mid-run where a concurrent release/agent could sweep them up
+  // (the commit-phase switch used to be the only branch point). ensureIssueBranch
+  // is idempotent, honours the project's issue_auto_branch opt-out, and on failure
+  // we log and let the run proceed on the current branch (commit-time switch is
+  // the backstop).
+  if (ghIssueNumber != null) {
+    try {
+      const { ensureIssueBranch } = await import('@/lib/github/issue-branch');
+      const branchResult = await ensureIssueBranch({
+        projectName,
+        projPath,
+        issueNumber: ghIssueNumber,
+        issueTitle: ghIssueTitle ?? '',
+      });
+      if (branchResult.status === 'error' || branchResult.status === 'pipeline-running') {
+        console.warn(`[run] ${projectName} issue-branch checkout not applied (${branchResult.status}); run proceeds on current branch`);
+      }
+    } catch (err) {
+      console.error('[run] ensureIssueBranch threw; run proceeds on current branch:', err);
+    }
+  }
+
   const job = createJob(projectName, 'run', 0, '', prompt, contextMeta || undefined, userPrompt || undefined, ghIssueNumber, ghIssueRepo || null, ghIssueTitle || null);
   job.provider = provider;
   job.model = model;

--- a/components/ErrorBanner.tsx
+++ b/components/ErrorBanner.tsx
@@ -17,9 +17,7 @@ export function ErrorBanner({ message, onDismiss }: ErrorBannerProps) {
         preWrap={false}
         className="mb-4 flex items-center gap-3 !rounded-lg !border-status-error !p-4"
       >
-        {/* Plain U+26A0 (no VS16) renders as a text-style glyph, matching the
-            codebase's monochrome style instead of the colour-emoji default. */}
-        <span className="text-lg leading-none">⚠</span>
+        <span aria-hidden="true" className="shrink-0 font-semibold leading-none">⚠</span>
         <span>{message}</span>
         <Button
           variant="ghost"

--- a/lib/agents/intake-workflow.ts
+++ b/lib/agents/intake-workflow.ts
@@ -606,6 +606,35 @@ async function startAgentStep(
     return;
   }
 
+  // Issue runs work on their OWN branch from the start, not on the default
+  // branch. Switch to fix/issue-<n> (cut fresh from origin/<default>) BEFORE the
+  // agent process spawns — otherwise the agent edits the default branch's working
+  // tree for the whole run and a concurrent release / another agent can sweep up
+  // its half-finished changes (the branch switch used to happen only at commit
+  // time, leaving issue work exposed on master mid-run). ensureIssueBranch is
+  // idempotent (already-on-branch → no-op, e.g. the issue-cruncher path that
+  // already checked out via pick_top), honours the project's issue_auto_branch
+  // opt-out, and on any failure we log and let the agent run on the current
+  // branch (the commit-time switch remains as the backstop).
+  if (job.ghIssueNumber != null) {
+    try {
+      const { ensureIssueBranch } = await import('@/lib/github/issue-branch');
+      const r = await ensureIssueBranch({
+        projectName: job.project,
+        projPath,
+        issueNumber: job.ghIssueNumber,
+        issueTitle: job.ghIssueTitle ?? '',
+      });
+      if (r.status === 'created' || r.status === 'reused') {
+        console.log(`[intake-workflow] ${jobId}: issue run isolated on branch ${r.branch} (${r.status}) before spawn`);
+      } else if (r.status === 'error' || r.status === 'pipeline-running') {
+        console.warn(`[intake-workflow] ${jobId}: issue-branch checkout not applied (${r.status}); agent runs on current branch`);
+      }
+    } catch (err) {
+      console.warn(`[intake-workflow] ${jobId}: ensureIssueBranch threw; agent runs on current branch:`, err);
+    }
+  }
+
   // Ensure the project's dev server is running for the duration of this
   // agent run (and any downstream release it triggers). Best-effort — log
   // and continue on failure so a flaky dev server start never blocks the

--- a/lib/github/issue-branch.ts
+++ b/lib/github/issue-branch.ts
@@ -80,7 +80,26 @@ export async function ensureIssueBranch(opts: {
     };
   }
 
-  const createR = await exec('git', ['-C', projPath, 'checkout', '-b', branch], { timeout: 10000 });
+  // Base the new branch on the LATEST origin/<default>, not the local (possibly
+  // stale) default — cutting from a stale local default is the root cause of
+  // "PRs suddenly conflict even though only we touch the repo": the branch is
+  // born behind origin and overlapping changes on the advancing default pile up
+  // into a merge conflict by PR time. Fetch first and branch off origin/<default>;
+  // fall back to local HEAD when origin is unavailable (offline) or the working
+  // tree can't be carried cleanly onto fresh origin (the push/pr-behind path
+  // rebases later in that case).
+  await exec('git', ['-C', projPath, 'fetch', '--quiet', 'origin', defaultBranch], { timeout: 30000 }).catch(() => {});
+  const originDefaultRef = `origin/${defaultBranch}`;
+  const haveOriginDefault =
+    (await exec('git', ['-C', projPath, 'rev-parse', '--verify', '--quiet', originDefaultRef], { timeout: 5000 })).exitCode === 0;
+  let createR = haveOriginDefault
+    ? await exec('git', ['-C', projPath, 'checkout', '-b', branch, originDefaultRef], { timeout: 15000 })
+    : await exec('git', ['-C', projPath, 'checkout', '-b', branch], { timeout: 10000 });
+  if (createR.exitCode !== 0 && haveOriginDefault) {
+    // Couldn't base on fresh origin (e.g. local tree changes can't carry) — fall
+    // back to a plain create from local HEAD.
+    createR = await exec('git', ['-C', projPath, 'checkout', '-b', branch], { timeout: 10000 });
+  }
   if (createR.exitCode === 0) {
     clearProjectDataCache();
     return { status: 'created', branch };


### PR DESCRIPTION
Closes #80

Implemented via TamTam from issue [#80](https://github.com/3h4x/tamtam/issues/80).